### PR TITLE
Use the old index name

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -11,7 +11,7 @@ function get (uuid, options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const qs = stringifyOptions(params);
 
-	return signedFetch(`https://next-elastic.ft.com/content/item/${uuid}/_source?${qs}`, {
+	return signedFetch(`https://next-elastic.ft.com/v3_api_v2/item/${uuid}/_source?${qs}`, {
 		timeout,
 		method: 'GET'
 	})

--- a/lib/mget.js
+++ b/lib/mget.js
@@ -20,7 +20,7 @@ function mget (options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elastic.ft.com/content/item/_mget', {
+	return signedFetch('https://next-elastic.ft.com/v3_api_v2/item/_mget', {
 		body,
 		timeout,
 		method: 'POST',

--- a/lib/search.js
+++ b/lib/search.js
@@ -29,7 +29,7 @@ function search (options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elastic.ft.com/content/item/_search', {
+	return signedFetch('https://next-elastic.ft.com/v3_api_v2/item/_search', {
 		body,
 		timeout,
 		method: 'POST',

--- a/test/spec/get-spec.js
+++ b/test/spec/get-spec.js
@@ -14,7 +14,7 @@ describe('Get', () => {
 	context('With options', () => {
 		it('accepts a source parameter', () => {
 			nock('https://next-elastic.ft.com')
-				.get(`/content/item/${fixture.id}/_source`)
+				.get(`/v3_api_v2/item/${fixture.id}/_source`)
 				.query((params) => {
 					return params._source === 'id,title';
 				})
@@ -27,7 +27,7 @@ describe('Get', () => {
 	context('Response - found', () => {
 		beforeEach(() => {
 			nock('https://next-elastic.ft.com')
-				.get(`/content/item/${fixture.id}/_source`)
+				.get(`/v3_api_v2/item/${fixture.id}/_source`)
 				.query(true)
 				.reply(200, fixture);
 		});
@@ -42,7 +42,7 @@ describe('Get', () => {
 	context('Response - not found', () => {
 		beforeEach(() => {
 			nock('https://next-elastic.ft.com')
-				.get(`/content/item/${fixture.id}/_source`)
+				.get(`/v3_api_v2/item/${fixture.id}/_source`)
 				.query(true)
 				.reply(404);
 		});

--- a/test/spec/mget-spec.js
+++ b/test/spec/mget-spec.js
@@ -17,7 +17,7 @@ describe('Multi get', () => {
 			const ids = [123, 456, 789];
 
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_mget', (body) => {
+				.post('/v3_api_v2/item/_mget', (body) => {
 					return body.ids.every((id, i) => id === ids[i]);
 				})
 				.reply(200, fixtureWithResults);
@@ -29,7 +29,7 @@ describe('Multi get', () => {
 			const source = 'id,title';
 
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_mget', (body) => {
+				.post('/v3_api_v2/item/_mget', (body) => {
 					return body._source === source;
 				})
 				.reply(200, fixtureWithResults);
@@ -41,7 +41,7 @@ describe('Multi get', () => {
 	context('Response - with results', () => {
 		beforeEach(() => {
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_mget')
+				.post('/v3_api_v2/item/_mget')
 				.reply(200, fixtureWithResults);
 		});
 
@@ -64,7 +64,7 @@ describe('Multi get', () => {
 	context('Response - no results', () => {
 		beforeEach(() => {
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_mget')
+				.post('/v3_api_v2/item/_mget')
 				.reply(200, fixtureNoResults);
 		});
 
@@ -84,7 +84,7 @@ describe('Multi get', () => {
 	context('Response - error', () => {
 		beforeEach(() => {
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_mget')
+				.post('/v3_api_v2/item/_mget')
 				.reply(500);
 		});
 

--- a/test/spec/search-spec.js
+++ b/test/spec/search-spec.js
@@ -19,7 +19,7 @@ describe('Search', () => {
 			const size = 20;
 
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_search', (body) => {
+				.post('/v3_api_v2/item/_search', (body) => {
 					return body.from === from && body.size === size;
 				})
 				.reply(200, fixtureWithResults);
@@ -31,7 +31,7 @@ describe('Search', () => {
 			const source = 'id,title';
 
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_search', (body) => {
+				.post('/v3_api_v2/item/_search', (body) => {
 					return body._source === source;
 				})
 				.reply(200, fixtureWithResults);
@@ -43,7 +43,7 @@ describe('Search', () => {
 	context('Response - with results', () => {
 		beforeEach(() => {
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_search')
+				.post('/v3_api_v2/item/_search')
 				.reply(200, fixtureWithResults);
 		});
 
@@ -64,7 +64,7 @@ describe('Search', () => {
 	context('Response - no results', () => {
 		beforeEach(() => {
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_search')
+				.post('/v3_api_v2/item/_search')
 				.reply(200, fixtureNoResults);
 		});
 
@@ -92,7 +92,7 @@ describe('Search', () => {
 	context('Response - error', () => {
 		beforeEach(() => {
 			nock('https://next-elastic.ft.com')
-				.post('/content/item/_search')
+				.post('/v3_api_v2/item/_search')
 				.reply(400, fixtureError);
 		});
 


### PR DESCRIPTION
Old cluster doesn't define permissions for the `content` index.

I'll open an issue to replace `v3_api_v2` with `content` once we're migrated.