### PR TITLE
Amend: move away from destructure

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.9.0
+    version: 4.3.0
 deployment:
   release:
     tag: /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/

--- a/lib/get.js
+++ b/lib/get.js
@@ -6,7 +6,9 @@ const DEFAULTS = {
 	_source: true
 };
 
-function get (uuid, options = {}, timeout = 3000) {
+function get (uuid, options, timeout) {
+	options = options || {};
+	timeout = timeout || 3000;
 	const params = Object.assign({}, DEFAULTS, options);
 	const qs = stringifyOptions(params);
 

--- a/lib/helpers/extract-source.js
+++ b/lib/helpers/extract-source.js
@@ -1,2 +1,2 @@
 // save time and memory by not creating a tonne of lambdas
-module.exports = ({ _source }) => _source;
+module.exports = (results) => results._source;

--- a/lib/helpers/stringify-options.js
+++ b/lib/helpers/stringify-options.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // node's querystring module does does handle arrays how we'd like
 function stringifyOptions (options) {
 	const output = [];

--- a/lib/mget.js
+++ b/lib/mget.js
@@ -15,7 +15,9 @@ function handleData (data) {
 	return results.map(extractSource);
 }
 
-function mget (options = {}, timeout = 3000) {
+function mget (options, timeout) {
+	options = options || {};
+	timeout = timeout || 3000;
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -12,7 +12,8 @@ const DEFAULTS = {
 
 function handleData (data) {
 	// extract the data we want
-	const { total, hits } = data.hits;
+	const total = data.hits.total;
+	const hits = data.hits.hits;
 
 	// pull out the content
 	const results = hits.map(extractSource);

--- a/lib/search.js
+++ b/lib/search.js
@@ -25,7 +25,9 @@ function handleData (data) {
 	return results;
 }
 
-function search (options = {}, timeout = 3000) {
+function search (options, timeout) {
+	options = options || {};
+	timeout = timeout || 3000;
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,3 +1,4 @@
+'strict mode';
 const search = require('./search');
 
 // property => alias (optional)
@@ -12,9 +13,9 @@ const PROPS = new Map([
 function pluck (rawTag) {
 	const newTag = {};
 
-	for (var attribute of PROPS) {
-		var alias = attribute[1];
-		var prop = attribute[0];
+	for (var attribute of PROPS) { // eslint-disable-line no-var
+		var alias = attribute[1]; // eslint-disable-line no-var
+		var prop = attribute[0]; // eslint-disable-line no-var
 		newTag[alias || prop] = rawTag[prop];
 	}
 

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -12,7 +12,9 @@ const PROPS = new Map([
 function pluck (rawTag) {
 	const newTag = {};
 
-	for (let [prop, alias] of PROPS) {
+	for (var attribute of PROPS) {
+		var alias = attribute[1];
+		var prop = attribute[0];
 		newTag[alias || prop] = rawTag[prop];
 	}
 
@@ -26,7 +28,8 @@ function handleData (data, uuid) {
 	}
 }
 
-function tag (uuid, timeout = 3000) {
+function tag (uuid, timeout) {
+	timeout = timeout || 3000;
 	const params = {
 		query: {
 			// avoid scoring to increase caching

--- a/test/spec/get-spec.js
+++ b/test/spec/get-spec.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const expect = require('chai').expect;
 const nock = require('nock');
 
 const subject = require('../../lib/get');

--- a/test/spec/mget-spec.js
+++ b/test/spec/mget-spec.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const expect = require('chai').expect;
 const nock = require('nock');
 
 const subject = require('../../lib/mget');

--- a/test/spec/search-spec.js
+++ b/test/spec/search-spec.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const expect = require('chai').expect;
 const nock = require('nock');
 
 const subject = require('../../lib/search');

--- a/test/spec/tag-spec.js
+++ b/test/spec/tag-spec.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const expect = require('chai').expect;
 const nock = require('nock');
 
 const subject = require('../../lib/tag');


### PR DESCRIPTION
Trying to migrate email non-gift share to n-es-client.

However it uses AWS lambda that only runs on node 4, which means it fails on destructuring.