### PR TITLE
Make requests to next-elasticsearch.nlb.ft.com

### DIFF
--- a/lib/count.js
+++ b/lib/count.js
@@ -14,7 +14,7 @@ function count (options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elastic.glb.ft.com/content/item/_count', {
+	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_count', {
 		body,
 		agent,
 		timeout,

--- a/lib/get.js
+++ b/lib/get.js
@@ -11,7 +11,7 @@ function get (uuid, options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const qs = stringifyOptions(params);
 
-	return signedFetch(`https://next-elastic.glb.ft.com/content/item/${uuid}/_source?${qs}`, {
+	return signedFetch(`https://next-elasticsearch.nlb.ft.com/content/item/${uuid}/_source?${qs}`, {
 		agent,
 		timeout,
 		method: 'GET'

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -3,7 +3,7 @@ const agent = require('./helpers/https-agent');
 const handleResponse = require('./helpers/handle-response');
 
 function mapping (timeout = 3000) {
-	return signedFetch('https://next-elastic.glb.ft.com/content/_mapping', {
+	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/_mapping', {
 		agent,
 		timeout,
 		method: 'GET'

--- a/lib/mget.js
+++ b/lib/mget.js
@@ -20,7 +20,7 @@ function mget (options = {}, timeout = 3000, dataHandler = handleData) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elastic.glb.ft.com/content/item/_mget', {
+	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_mget', {
 		body,
 		agent,
 		timeout,

--- a/lib/msearch.js
+++ b/lib/msearch.js
@@ -31,7 +31,7 @@ function search (queries = [], timeout = 3000, dataHandler = handleData) {
 
 	const body = lines.map(JSON.stringify).join('\n')
 
-	return signedFetch('https://next-elastic.glb.ft.com/content/item/_msearch', {
+	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_msearch', {
 		body,
 		agent,
 		timeout,

--- a/lib/search.js
+++ b/lib/search.js
@@ -29,7 +29,7 @@ function search (options = {}, timeout = 3000, dataHandler = handleData) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elastic.glb.ft.com/content/item/_search', {
+	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_search', {
 		body,
 		agent,
 		timeout,

--- a/test/spec/concept-spec.js
+++ b/test/spec/concept-spec.js
@@ -16,7 +16,7 @@ describe('Concept', () => {
 		const id = '73cc33b5-d0cb-3815-8347-bc49e1ddbd5c';
 
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_search')
 				.reply(200, fixtureFound);
 		});
@@ -51,7 +51,7 @@ describe('Concept', () => {
 		const id = '73cc33b5-d0cb-3815-8347-bg24c232324c';
 
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_search')
 				.reply(200, fixtureNotFound);
 		});
@@ -65,7 +65,7 @@ describe('Concept', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_search')
 				.reply(500);
 		});

--- a/test/spec/count-spec.js
+++ b/test/spec/count-spec.js
@@ -18,7 +18,7 @@ describe('Count', () => {
 				}
 			};
 
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_count', (body) => {
 					return body.query.term['metadata.idV1'] === 'Ng==-U2VjdGlvbnM=';
 				})
@@ -30,7 +30,7 @@ describe('Count', () => {
 
 	context('Response - success', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_count')
 				.reply(200, fixture);
 		});
@@ -45,7 +45,7 @@ describe('Count', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_count')
 				.reply(500);
 		});

--- a/test/spec/get-spec.js
+++ b/test/spec/get-spec.js
@@ -13,7 +13,7 @@ describe('Get', () => {
 
 	context('With options', () => {
 		it('accepts a source parameter', () => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.get(`/content/item/${fixture.id}/_source`)
 				.query((params) => {
 					return params._source === 'id,title';
@@ -26,7 +26,7 @@ describe('Get', () => {
 
 	context('Response - found', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.get(`/content/item/${fixture.id}/_source`)
 				.query(true)
 				.reply(200, fixture);
@@ -41,7 +41,7 @@ describe('Get', () => {
 
 	context('Response - not found', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.get(`/content/item/${fixture.id}/_source`)
 				.query(true)
 				.reply(404);

--- a/test/spec/mget-spec.js
+++ b/test/spec/mget-spec.js
@@ -16,7 +16,7 @@ describe('Multi get', () => {
 		it('accepts an IDs parameter', () => {
 			const ids = [123, 456, 789];
 
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_mget', (body) => {
 					return body.ids.every((id, i) => id === ids[i]);
 				})
@@ -28,7 +28,7 @@ describe('Multi get', () => {
 		it('accepts a source parameter', () => {
 			const source = 'id,title';
 
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_mget', (body) => {
 					return body._source === source;
 				})
@@ -40,7 +40,7 @@ describe('Multi get', () => {
 
 	context('Response - with results', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_mget')
 				.reply(200, fixtureWithResults);
 		});
@@ -63,7 +63,7 @@ describe('Multi get', () => {
 
 	context('Response - no results', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_mget')
 				.reply(200, fixtureNoResults);
 		});
@@ -83,7 +83,7 @@ describe('Multi get', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_mget')
 				.reply(500);
 		});

--- a/test/spec/msearch-spec.js
+++ b/test/spec/msearch-spec.js
@@ -15,7 +15,7 @@ describe('msearch', () => {
 
 	context('With options', () => {
 		it('formats each header and query onto a line', () => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_msearch', (body) => {
 					const lines = body.split(/\n/).map(JSON.parse);
 
@@ -32,7 +32,7 @@ describe('msearch', () => {
 		});
 
 		it('sets defaults for each query', () => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_msearch', (body) => {
 					const lines = body.split(/\n/).map(JSON.parse);
 
@@ -52,7 +52,7 @@ describe('msearch', () => {
 
 	context('Response - with results', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_msearch')
 				.reply(200, fixtureWithResults);
 		});
@@ -94,7 +94,7 @@ describe('msearch', () => {
 
 	context('Response - no results', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_msearch')
 				.reply(200, fixtureNoResults);
 		});
@@ -116,7 +116,7 @@ describe('msearch', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_msearch')
 				.reply(400, fixtureError);
 		});

--- a/test/spec/search-spec.js
+++ b/test/spec/search-spec.js
@@ -18,7 +18,7 @@ describe('Search', () => {
 			const from = 10;
 			const size = 20;
 
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_search', (body) => {
 					return body.from === from && body.size === size;
 				})
@@ -30,7 +30,7 @@ describe('Search', () => {
 		it('accepts a source parameter', () => {
 			const source = 'id,title';
 
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_search', (body) => {
 					return body._source === source;
 				})
@@ -42,7 +42,7 @@ describe('Search', () => {
 
 	context('Response - with results', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_search')
 				.reply(200, fixtureWithResults);
 		});
@@ -71,7 +71,7 @@ describe('Search', () => {
 
 	context('Response - no results', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_search')
 				.reply(200, fixtureNoResults);
 		});
@@ -91,7 +91,7 @@ describe('Search', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elastic.glb.ft.com')
+			nock('https://next-elasticsearch.nlb.ft.com')
 				.post('/content/item/_search')
 				.reply(400, fixtureError);
 		});


### PR DESCRIPTION
As part of the DNS migration we've had to move to a separate DNS zone (`nlb.ft.com`).

We tried setting up with what everyone else is using, octodns in [Financial-Times/dns](https://github.com/Financial-Times/dns), but unfortunately there is an issue with the health checks not working for our US Elasticsearch cluster if the request has a host header ending in a period.

I've worked with Nayana's team to configure a geo load balanced address using CloudFormation instead.

Related previous PR is #41. 