### PR TITLE
Make the Elasticsearch hostname configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,10 @@
+const logger = require('@financial-times/n-logger').default;
+
+const ELASTICSEARCH_PRODUCTION_HOSTNAME = 'next-elasticsearch.nlb.ft.com';
+const ELASTICSEARCH_DEVELOPMENT_HOSTNAME = 'search-next-elasticsearch-dev-yh4wwly56xcwvmnlfqwgliizpe.eu-west-1.es.amazonaws.com';
+
+global.ELASTICSEARCH_HOSTNAME = ELASTICSEARCH_PRODUCTION_HOSTNAME;
+
 module.exports = {
 	search: require('./lib/search'),
 	count: require('./lib/count'),
@@ -6,5 +13,13 @@ module.exports = {
 	tag: require('./lib/tag'),
 	concept: require('./lib/concept'),
 	mapping: require('./lib/mapping'),
-	msearch: require('./lib/msearch')
+	msearch: require('./lib/msearch'),
+	useDevelopmentCluster: () => {
+		global.ELASTICSEARCH_HOSTNAME = ELASTICSEARCH_DEVELOPMENT_HOSTNAME;
+
+		logger.debug({
+			event: 'ES_CLIENT_USING_DEVELOPMENT_CLUSTER',
+			ELASTICSEARCH_HOSTNAME: global.ELASTICSEARCH_HOSTNAME
+		});
+	}
 };

--- a/lib/count.js
+++ b/lib/count.js
@@ -14,7 +14,7 @@ function count (options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_count', {
+	return signedFetch(`https://${global.ELASTICSEARCH_HOSTNAME}/content/item/_count`, {
 		body,
 		agent,
 		timeout,

--- a/lib/get.js
+++ b/lib/get.js
@@ -11,7 +11,7 @@ function get (uuid, options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const qs = stringifyOptions(params);
 
-	return signedFetch(`https://next-elasticsearch.nlb.ft.com/content/item/${uuid}/_source?${qs}`, {
+	return signedFetch(`https://${global.ELASTICSEARCH_HOSTNAME}/content/item/${uuid}/_source?${qs}`, {
 		agent,
 		timeout,
 		method: 'GET'

--- a/lib/helpers/hostname.js
+++ b/lib/helpers/hostname.js
@@ -1,0 +1,18 @@
+const logger = require('@financial-times/n-logger').default;
+
+const ELASTICSEARCH_PRODUCTION_HOSTNAME = 'next-elasticsearch.nlb.ft.com';
+const ELASTICSEARCH_DEVELOPMENT_HOSTNAME = 'search-next-elasticsearch-dev-yh4wwly56xcwvmnlfqwgliizpe.eu-west-1.es.amazonaws.com';
+
+let ELASTICSEARCH_HOSTNAME = ELASTICSEARCH_PRODUCTION_HOSTNAME;
+
+module.exports = {
+	get: () => ELASTICSEARCH_HOSTNAME,
+	useDevelopmentCluster: () => {
+		ELASTICSEARCH_HOSTNAME = ELASTICSEARCH_DEVELOPMENT_HOSTNAME;
+
+		logger.debug({
+			event: 'ES_CLIENT_USE_DEVELOPMENT_CLUSTER',
+			ELASTICSEARCH_HOSTNAME
+		});
+	}
+};

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -3,7 +3,7 @@ const agent = require('./helpers/https-agent');
 const handleResponse = require('./helpers/handle-response');
 
 function mapping (timeout = 3000) {
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/_mapping', {
+	return signedFetch(`https://${global.ELASTICSEARCH_HOSTNAME}/content/_mapping`, {
 		agent,
 		timeout,
 		method: 'GET'

--- a/lib/mget.js
+++ b/lib/mget.js
@@ -20,7 +20,7 @@ function mget (options = {}, timeout = 3000, dataHandler = handleData) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_mget', {
+	return signedFetch(`https://${global.ELASTICSEARCH_HOSTNAME}/content/item/_mget`, {
 		body,
 		agent,
 		timeout,

--- a/lib/msearch.js
+++ b/lib/msearch.js
@@ -29,9 +29,9 @@ function search (queries = [], timeout = 3000, dataHandler = handleData) {
 		return accumulator;
 	}, []);
 
-	const body = lines.map(JSON.stringify).join('\n')
+	const body = lines.map(JSON.stringify).join('\n');
 
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_msearch', {
+	return signedFetch(`https://${global.ELASTICSEARCH_HOSTNAME}/content/item/_msearch`, {
 		body,
 		agent,
 		timeout,

--- a/lib/search.js
+++ b/lib/search.js
@@ -29,7 +29,7 @@ function search (options = {}, timeout = 3000, dataHandler = handleData) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_search', {
+	return signedFetch(`https://${global.ELASTICSEARCH_HOSTNAME}/content/item/_search`, {
 		body,
 		agent,
 		timeout,


### PR DESCRIPTION
> IMPORTANT: These changes are hacky and not intended to be merged or published to npm.

This allows you to decide whether you want to make requests to the production or the development Elasticsearch cluster.

Usage:

1. In your Node.js app directory, install the `n-es-client` dependency from this branch on GitHub:

```bash
npm install github:Financial-Times/n-es-client#use-development-cluster
```

2. At the top of the app's `app.js` configure `n-es-client` to make requests to the development cluster:

```javascript
const esClient = require('@financial-times/n-es-client');
esClient.useDevelopmentCluster();
```

This configuration will apply to anywhere in your app that you use `n-es-client`.