### PR TITLE
This commit is used for a talking point - please don't merge

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -3,6 +3,17 @@ const agent = require('./helpers/https-agent');
 const handleResponse = require('./helpers/handle-response');
 const extractSource = require('./helpers/extract-source');
 
+
+const EXCLUDE_BLOG_POSTS = {
+	bool: {
+		must_not: {
+			term: {
+				type: 'live-blog-post'
+			}
+		}
+	}
+};
+
 const DEFAULTS = {
 	query: { match_all: {} },
 	from: 0,
@@ -10,6 +21,7 @@ const DEFAULTS = {
 	sort: { publishedDate: 'desc' },
 	_source: true
 };
+
 
 function handleData (data) {
 	// extract the data we want
@@ -26,6 +38,12 @@ function handleData (data) {
 }
 
 function search (options = {}, timeout = 3000, dataHandler = handleData) {
+	
+	if (Boolean(options.includeBlogPosts) === false) {
+		const boolQuery = options.query.bool ? Object.assign({}, options.query.bool, EXCLUDE_BLOG_POSTS.bool) : EXCLUDE_BLOG_POSTS;
+		options.query.bool = boolQuery;
+ 	}
+	
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 


### PR DESCRIPTION
I am adding this code in a quick and nasty way so I can open a PR to discuss it with other engineers. I want to see if an option like this would be a good idea but the code itself is quick and nasty and should be improved before being used.

## Question?

Do we think it would be a good idea to add something like this (but nicer) to prevent blog posts being returned by default? This means pages such as stream pages wouldn't get blog posts even if they are tagged with the concept.

The `includeBlogPosts` option can be passed in if a specific app wants to receive blog posts

## Known issues

Lots of things use this library to search ES but not everything does so it might not fix everything. One thing it certainly won't fix is the app which makes its requests to ES from its PHP api.