### PR TITLE
Make requests to next-elasticsearch-v7.gslb.ft.com

### DIFF
--- a/lib/count.js
+++ b/lib/count.js
@@ -14,7 +14,7 @@ function count (options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_count', {
+	return signedFetch('https://next-elasticsearch-v7.gslb.ft.com/content/_count', {
 		body,
 		agent,
 		timeout,

--- a/lib/get.js
+++ b/lib/get.js
@@ -11,7 +11,7 @@ function get (uuid, options = {}, timeout = 3000) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const qs = stringifyOptions(params);
 
-	return signedFetch(`https://next-elasticsearch.nlb.ft.com/content/item/${uuid}/_source?${qs}`, {
+	return signedFetch(`https://next-elasticsearch-v7.gslb.ft.com/content/_doc/${uuid}/_source?${qs}`, {
 		agent,
 		timeout,
 		method: 'GET'

--- a/lib/mapping.js
+++ b/lib/mapping.js
@@ -3,7 +3,7 @@ const agent = require('./helpers/https-agent');
 const handleResponse = require('./helpers/handle-response');
 
 function mapping (timeout = 3000) {
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/_mapping', {
+	return signedFetch('https://next-elasticsearch-v7.gslb.ft.com/content/_mapping', {
 		agent,
 		timeout,
 		method: 'GET'

--- a/lib/mget.js
+++ b/lib/mget.js
@@ -4,8 +4,7 @@ const handleResponse = require('./helpers/handle-response');
 const extractSource = require('./helpers/extract-source');
 
 const DEFAULTS = {
-	ids: [],
-	_source: true
+	ids: []
 };
 
 function handleData (data) {
@@ -20,7 +19,7 @@ function mget (options = {}, timeout = 3000, dataHandler = handleData) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_mget', {
+	return signedFetch('https://next-elasticsearch-v7.gslb.ft.com/content/_mget', {
 		body,
 		agent,
 		timeout,

--- a/lib/msearch.js
+++ b/lib/msearch.js
@@ -13,7 +13,7 @@ const DEFAULTS = {
 function handleData ({ responses }) {
 	return responses.map((data) => {
 		return {
-			total: data.hits.total,
+			total: data.hits.total.value,
 			hits: data.hits.hits.map(extractSource)
 		};
 	});
@@ -29,9 +29,9 @@ function search (queries = [], timeout = 3000, dataHandler = handleData) {
 		return accumulator;
 	}, []);
 
-	const body = lines.map(JSON.stringify).join('\n')
+	const body = lines.map(JSON.stringify).join('\n');
 
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_msearch', {
+	return signedFetch('https://next-elasticsearch-v7.gslb.ft.com/content/_msearch', {
 		body,
 		agent,
 		timeout,

--- a/lib/search.js
+++ b/lib/search.js
@@ -19,7 +19,7 @@ function handleData (data) {
 	const results = hits.map(extractSource);
 
 	// the total is handy so tack that on
-	results.total = total;
+	results.total = total.value;
 
 	// return the array of content
 	return results;
@@ -29,7 +29,7 @@ function search (options = {}, timeout = 3000, dataHandler = handleData) {
 	const params = Object.assign({}, DEFAULTS, options);
 	const body = JSON.stringify(params);
 
-	return signedFetch('https://next-elasticsearch.nlb.ft.com/content/item/_search', {
+	return signedFetch('https://next-elasticsearch-v7.gslb.ft.com/content/_search', {
 		body,
 		agent,
 		timeout,

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -6,46 +6,43 @@ module.exports = {
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'cce58e8e-158c-11e7-80f4-13e067d5072c', // README.md
-			'0615fc8c-1558-11e7-80f4-13e067d5072c', // README.md
-			'dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54', // README.md
-			'ff03ad34-4367-11e7-8519-9f94ee97d996', // test/fixtures/
-			'2665a6bc-e383-3540-8c71-334aabc60c4d', // test/fixtures/
-			'51649457-e3e7-3751-bf70-5f3d282bc9e4', // test/fixtures/
-			'423f0857-e5b5-3256-a8b8-857e2378f433', // test/fixtures/
-			'2c563220-391b-3ecd-bb41-d54ac542c872', // test/fixtures/
-			'3cd493ab-5648-3166-addc-69e9591c9843', // test/fixtures/
-			'1ddb5be2-a098-38e0-b510-e37bf4f494b1', // test/fixtures/
-			'10445659-5133-3551-b27a-371f7ae449b5', // test/fixtures/
-			'21715af3-3c85-3134-9fb8-8e688a0f8985', // test/fixtures/
-			'a845f747-276b-3435-aa0e-98c436676246', // test/fixtures/
-			'9b40e89c-e87b-3d4f-b72c-2cf7511d2146', // test/fixtures/
-			'b2708390-ac5c-3592-9ab2-b0d09c40398d', // test/fixtures/
-			'852939c8-859c-361e-8514-f82f6c041580', // test/fixtures/
-			'9151841f-0686-3531-9486-f89ade98a65d', // test/fixtures/
-			'ce93225f-bb29-3a4f-936a-f852dfe740da', // test/fixtures/
-			'1b4b842d-8bae-3b78-9c50-5a7a0d60e2ef', // test/fixtures/
-			'73cc33b5-d0cb-3815-8347-bc49e1ddbd5c', // test/fixtures/
-			'81fbe64c-155d-3e74-bb40-c6fe829f4d7e', // test/fixtures/
-			'af1f01be-1564-11e7-b0c1-37e417ee6c76', // test/fixtures/
-			'ff1f01be-1564-11e7-b0c1-37e417ee6c76', // test/fixtures/
-			'ff3d0c6e-153d-11e7-b0c1-37e417ee6c76', // test/fixtures/
-			'ff90a2d8-148f-11e7-80f4-13e067d5072c', // test/fixtures/
-			'ff032668-155f-11e7-80f4-13e067d5072c', // test/fixtures/
-			'803d0c6e-153d-11e7-b0c1-37e417ee6c76', // test/fixtures/
-			'2690a2d8-148f-11e7-80f4-13e067d5072c', // test/fixtures/
-			'6b032668-155f-11e7-80f4-13e067d5072c', // test/fixtures/
-			'64e70fac-155e-11e7-b0c1-37e417ee6c76', // test/fixtures/
-			'2331a33d-c5db-3a50-a549-8746f3067f0f', // test/fixtures/
-			'c3f81a26-155f-11e7-80f4-13e067d5072c', // test/fixtures/
-			'88f5d2a6-155a-11e7-b0c1-37e417ee6c76', // test/fixtures/
-			'aa8fbace-14c6-11e7-80f4-13e067d5072c', // test/fixtures/
-			'201cf2f0-153c-11e7-b0c1-37e417ee6c76', // test/fixtures/
-			'30364c64-f150-11dc-a91a-0000779fd2ac', // test/fixtures/
-			'f3ab96be-b72e-11e7-8c12-5661783e5589', // test/fixtures/
-			'ab0cf1fa-4fbe-11e7-a1f2-db19572361bb', // test/fixtures/
-			'3ace6a68-efa9-11d9-bd3b-00000e2511c8', // test/fixtures/
-			'73cc33b5-d0cb-3815-8347-bg24c232324c'  // test/spec/
+			'cce58e8e-158c-11e7-80f4-13e067d5072c', // README.md:10|43|54|59|103
+			'0615fc8c-1558-11e7-80f4-13e067d5072c', // README.md:60|104
+			'dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54', // README.md:75|90
+			'26b07d2a-3715-11e3-9603-00144feab7de', // test/fixtures/concept-found.json:20
+			'80871faa-d16f-4c9f-b310-df42104dcecc', // test/fixtures/concept-found.json:33|38|40|41, test/spec/concept-spec.js:16
+			'f90747af-9632-4bd3-9082-1454e58dd86f', // test/fixtures/concept-found.json:50|54|56|57
+			'5216ff2e-a6ed-42b2-a613-109fc6491ba2', // test/fixtures/concept-found.json:66|70
+			'c47f4dfc-6879-4e95-accf-ca8cbe6a1f69', // test/fixtures/concept-found.json:82|86
+			'5f93fe95-f487-4aba-abce-39e7d783047d', // test/fixtures/concept-found.json:98|102
+			'97133bf5-c958-4c69-9e0e-44874679cedc', // test/fixtures/concept-found.json:114|118
+			'f95dd6f8-9ab9-407f-b8b3-9239815216b5', // test/fixtures/concept-found.json:130|134
+			'9d13b836-df76-4445-b599-10ae378680f0', // test/fixtures/concept-found.json:146|150
+			'6bade25b-56b3-4409-8d32-c131666d9acb', // test/fixtures/concept-found.json:162|166
+			'a579350c-61ce-4c00-97ca-ddaa2e0cacf6', // test/fixtures/concept-found.json:179|183|185|186
+			'01dcc40b-8099-35f2-adbf-637c9b7b160b', // test/fixtures/concept-found.json:195|199|201|202
+			'0236bde5-98d7-3dd6-8819-e0bc25124595', // test/fixtures/concept-found.json:211|215|217|218
+			'67fb70ae-b970-4bd1-92ea-761618ae8cb7', // test/fixtures/concept-found.json:227|231
+			'af1f01be-1564-11e7-b0c1-37e417ee6c76', // test/fixtures/get-found.json:2|5, test/fixtures/search-with-results.json:20|23|26
+			'ff1f01be-1564-11e7-b0c1-37e417ee6c76', // test/fixtures/mget-no-results.json:6|12|18|24
+			'9ef3a1c5-328c-460d-9261-33ea991cae62', // test/fixtures/mget-with-results.json:6|12|15
+			'02ecd3cc-40ee-4712-ae9a-d9b41427d6e9', // test/fixtures/mget-with-results.json:21|27|30
+			'f5c8f565-3463-4a18-b64b-24075d83ad57', // test/fixtures/mget-with-results.json:36|42|45
+			'e1a526ba-f1c8-45df-88f1-9aa32fa4af3e', // test/fixtures/mget-with-results.json:51|57|60
+			'30364c64-f150-11dc-a91a-0000779fd2ac', // test/fixtures/msearch-with-results.json:23
+			'f3ab96be-b72e-11e7-8c12-5661783e5589', // test/fixtures/msearch-with-results.json:32
+			'ab0cf1fa-4fbe-11e7-a1f2-db19572361bb', // test/fixtures/msearch-with-results.json:61
+			'3ace6a68-efa9-11d9-bd3b-00000e2511c8', // test/fixtures/msearch-with-results.json:70
+			'803d0c6e-153d-11e7-b0c1-37e417ee6c76', // test/fixtures/search-with-results.json:35|38|41
+			'2690a2d8-148f-11e7-80f4-13e067d5072c', // test/fixtures/search-with-results.json:50|53|56
+			'6b032668-155f-11e7-80f4-13e067d5072c', // test/fixtures/search-with-results.json:65|68|71
+			'64e70fac-155e-11e7-b0c1-37e417ee6c76', // test/fixtures/search-with-results.json:80|83|86
+			'2331a33d-c5db-3a50-a549-8746f3067f0f', // test/fixtures/search-with-results.json:95|98|101
+			'c3f81a26-155f-11e7-80f4-13e067d5072c', // test/fixtures/search-with-results.json:110|113|116
+			'88f5d2a6-155a-11e7-b0c1-37e417ee6c76', // test/fixtures/search-with-results.json:125|128|131
+			'aa8fbace-14c6-11e7-80f4-13e067d5072c', // test/fixtures/search-with-results.json:140|143|146
+			'201cf2f0-153c-11e7-b0c1-37e417ee6c76', // test/fixtures/search-with-results.json:155|158|161
+			'73cc33b5-d0cb-3815-8347-bg24c232324c' // test/spec/concept-spec.js:51
 		]
 	}
 };

--- a/test/fixtures/concept-found.json
+++ b/test/fixtures/concept-found.json
@@ -1,139 +1,28 @@
 {
-  "took": 4,
+  "took": 16,
   "timed_out": false,
   "_shards": {
     "total": 4,
     "successful": 4,
+    "skipped": 0,
     "failed": 0
   },
   "hits": {
-    "total": 6043,
-    "max_score": null,
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
+    "max_score": 1.0,
     "hits": [
       {
-        "_index": "content_2017-05-26",
-        "_type": "item",
-        "_id": "ff03ad34-4367-11e7-8519-9f94ee97d996",
-        "_score": null,
+        "_index": "content_2021-01-27",
+        "_type": "_doc",
+        "_id": "26b07d2a-3715-11e3-9603-00144feab7de",
+        "_score": 1.0,
         "_source": {
           "annotations": [
             {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/Topic"
-              ],
-              "apiUrl": "http://api.ft.com/things/2665a6bc-e383-3540-8c71-334aabc60c4d",
-              "directType": "http://www.ft.com/ontology/Topic",
-              "prefLabel": "EU digital single market",
-              "id": "2665a6bc-e383-3540-8c71-334aabc60c4d",
-              "type": "TOPIC",
-              "url": "https://www.ft.com/stream/2665a6bc-e383-3540-8c71-334aabc60c4d"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/Topic"
-              ],
-              "apiUrl": "http://api.ft.com/things/51649457-e3e7-3751-bf70-5f3d282bc9e4",
-              "directType": "http://www.ft.com/ontology/Topic",
-              "prefLabel": "Internet privacy",
-              "id": "51649457-e3e7-3751-bf70-5f3d282bc9e4",
-              "type": "TOPIC",
-              "url": "https://www.ft.com/stream/51649457-e3e7-3751-bf70-5f3d282bc9e4"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/organisation/Organisation"
-              ],
-              "apiUrl": "http://api.ft.com/organisations/423f0857-e5b5-3256-a8b8-857e2378f433",
-              "directType": "http://www.ft.com/ontology/organisation/Organisation",
-              "prefLabel": "European Union",
-              "id": "423f0857-e5b5-3256-a8b8-857e2378f433",
-              "type": "ORGANISATION",
-              "url": "https://www.ft.com/stream/423f0857-e5b5-3256-a8b8-857e2378f433"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/organisation/Organisation"
-              ],
-              "apiUrl": "http://api.ft.com/organisations/2c563220-391b-3ecd-bb41-d54ac542c872",
-              "directType": "http://www.ft.com/ontology/organisation/Organisation",
-              "prefLabel": "ZEIT ONLINE GmbH",
-              "id": "2c563220-391b-3ecd-bb41-d54ac542c872",
-              "type": "ORGANISATION",
-              "url": "https://www.ft.com/stream/2c563220-391b-3ecd-bb41-d54ac542c872"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/classification/Classification",
-                "http://www.ft.com/ontology/Section"
-              ],
-              "apiUrl": "http://api.ft.com/things/3cd493ab-5648-3166-addc-69e9591c9843",
-              "directType": "http://www.ft.com/ontology/Section",
-              "prefLabel": "Europe",
-              "id": "3cd493ab-5648-3166-addc-69e9591c9843",
-              "type": "SECTION",
-              "url": "https://www.ft.com/stream/3cd493ab-5648-3166-addc-69e9591c9843"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/classification/isPrimarilyClassifiedBy",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/classification/Classification",
-                "http://www.ft.com/ontology/Section"
-              ],
-              "apiUrl": "http://api.ft.com/things/1ddb5be2-a098-38e0-b510-e37bf4f494b1",
-              "directType": "http://www.ft.com/ontology/Section",
-              "prefLabel": "Media",
-              "id": "1ddb5be2-a098-38e0-b510-e37bf4f494b1",
-              "type": "SECTION",
-              "url": "https://www.ft.com/stream/1ddb5be2-a098-38e0-b510-e37bf4f494b1"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/classification/Classification",
-                "http://www.ft.com/ontology/Section"
-              ],
-              "apiUrl": "http://api.ft.com/things/10445659-5133-3551-b27a-371f7ae449b5",
-              "directType": "http://www.ft.com/ontology/Section",
-              "prefLabel": "European Companies",
-              "id": "10445659-5133-3551-b27a-371f7ae449b5",
-              "type": "SECTION",
-              "url": "https://www.ft.com/stream/10445659-5133-3551-b27a-371f7ae449b5"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/organisation/Organisation"
-              ],
-              "apiUrl": "http://api.ft.com/organisations/21715af3-3c85-3134-9fb8-8e688a0f8985",
-              "directType": "http://www.ft.com/ontology/organisation/Organisation",
-              "prefLabel": "Associated Newspapers Ltd.",
-              "id": "21715af3-3c85-3134-9fb8-8e688a0f8985",
-              "type": "ORGANISATION",
-              "url": "https://www.ft.com/stream/21715af3-3c85-3134-9fb8-8e688a0f8985"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
+              "predicate": "http://www.ft.com/ontology/annotation/about",
               "types": [
                 "http://www.ft.com/ontology/core/Thing",
                 "http://www.ft.com/ontology/concept/Concept",
@@ -141,18 +30,143 @@
                 "http://www.ft.com/ontology/company/Company",
                 "http://www.ft.com/ontology/company/PublicCompany"
               ],
-              "apiUrl": "http://api.ft.com/organisations/a845f747-276b-3435-aa0e-98c436676246",
+              "apiUrl": "http://api.ft.com/organisations/80871faa-d16f-4c9f-b310-df42104dcecc",
               "directType": "http://www.ft.com/ontology/company/PublicCompany",
-              "prefLabel": "Daily Mail & General Trust Plc",
-              "attributes": [
-                {
-                  "value": "BBG000BDDZY9",
-                  "key": "FIGI"
-                }
-              ],
-              "id": "a845f747-276b-3435-aa0e-98c436676246",
+              "FIGI": "BBG000DZG349",
+              "prefLabel": "Rio Tinto PLC",
+              "preposition": "on",
+              "id": "80871faa-d16f-4c9f-b310-df42104dcecc",
               "type": "ORGANISATION",
-              "url": "https://www.ft.com/stream/a845f747-276b-3435-aa0e-98c436676246"
+              "relativeUrl": "/stream/80871faa-d16f-4c9f-b310-df42104dcecc",
+              "url": "https://www.ft.com/stream/80871faa-d16f-4c9f-b310-df42104dcecc"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/organisation/Organisation"
+              ],
+              "apiUrl": "http://api.ft.com/organisations/f90747af-9632-4bd3-9082-1454e58dd86f",
+              "directType": "http://www.ft.com/ontology/organisation/Organisation",
+              "prefLabel": "BSG Resources Ltd",
+              "preposition": "on",
+              "id": "f90747af-9632-4bd3-9082-1454e58dd86f",
+              "type": "ORGANISATION",
+              "relativeUrl": "/stream/f90747af-9632-4bd3-9082-1454e58dd86f",
+              "url": "https://www.ft.com/stream/f90747af-9632-4bd3-9082-1454e58dd86f"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/Topic"
+              ],
+              "apiUrl": "http://api.ft.com/things/5216ff2e-a6ed-42b2-a613-109fc6491ba2",
+              "directType": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "Energy sector",
+              "preposition": "on",
+              "id": "5216ff2e-a6ed-42b2-a613-109fc6491ba2",
+              "type": "TOPIC",
+              "relativeUrl": "/companies/energy",
+              "url": "https://www.ft.com/companies/energy"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/Topic"
+              ],
+              "apiUrl": "http://api.ft.com/things/c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+              "directType": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "Companies",
+              "preposition": "on",
+              "id": "c47f4dfc-6879-4e95-accf-ca8cbe6a1f69",
+              "type": "TOPIC",
+              "relativeUrl": "/companies",
+              "url": "https://www.ft.com/companies"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/Topic"
+              ],
+              "apiUrl": "http://api.ft.com/things/5f93fe95-f487-4aba-abce-39e7d783047d",
+              "directType": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "Americas companies",
+              "preposition": "on",
+              "id": "5f93fe95-f487-4aba-abce-39e7d783047d",
+              "type": "TOPIC",
+              "relativeUrl": "/companies/americas",
+              "url": "https://www.ft.com/companies/americas"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/Topic"
+              ],
+              "apiUrl": "http://api.ft.com/things/97133bf5-c958-4c69-9e0e-44874679cedc",
+              "directType": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "Asia-Pacific companies",
+              "preposition": "on",
+              "id": "97133bf5-c958-4c69-9e0e-44874679cedc",
+              "type": "TOPIC",
+              "relativeUrl": "/companies/asia-pacific",
+              "url": "https://www.ft.com/companies/asia-pacific"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/Topic"
+              ],
+              "apiUrl": "http://api.ft.com/things/f95dd6f8-9ab9-407f-b8b3-9239815216b5",
+              "directType": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "Mining",
+              "preposition": "on",
+              "id": "f95dd6f8-9ab9-407f-b8b3-9239815216b5",
+              "type": "TOPIC",
+              "relativeUrl": "/companies/mining",
+              "url": "https://www.ft.com/companies/mining"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/Topic"
+              ],
+              "apiUrl": "http://api.ft.com/things/9d13b836-df76-4445-b599-10ae378680f0",
+              "directType": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "Mergers & Acquisitions",
+              "preposition": "on",
+              "id": "9d13b836-df76-4445-b599-10ae378680f0",
+              "type": "TOPIC",
+              "relativeUrl": "/mergers-acquisitions",
+              "url": "https://www.ft.com/mergers-acquisitions"
+            },
+            {
+              "predicate": "http://www.ft.com/ontology/annotation/about",
+              "types": [
+                "http://www.ft.com/ontology/core/Thing",
+                "http://www.ft.com/ontology/concept/Concept",
+                "http://www.ft.com/ontology/Topic"
+              ],
+              "apiUrl": "http://api.ft.com/things/6bade25b-56b3-4409-8d32-c131666d9acb",
+              "directType": "http://www.ft.com/ontology/Topic",
+              "prefLabel": "UK companies",
+              "preposition": "on",
+              "id": "6bade25b-56b3-4409-8d32-c131666d9acb",
+              "type": "TOPIC",
+              "relativeUrl": "/companies/uk",
+              "url": "https://www.ft.com/companies/uk"
             },
             {
               "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
@@ -162,117 +176,65 @@
                 "http://www.ft.com/ontology/classification/Classification",
                 "http://www.ft.com/ontology/Genre"
               ],
-              "apiUrl": "http://api.ft.com/things/9b40e89c-e87b-3d4f-b72c-2cf7511d2146",
+              "apiUrl": "http://api.ft.com/things/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
               "directType": "http://www.ft.com/ontology/Genre",
               "prefLabel": "News",
-              "id": "9b40e89c-e87b-3d4f-b72c-2cf7511d2146",
+              "preposition": "",
+              "id": "a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
               "type": "GENRE",
-              "url": "https://www.ft.com/stream/9b40e89c-e87b-3d4f-b72c-2cf7511d2146"
+              "relativeUrl": "/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6",
+              "url": "https://www.ft.com/stream/a579350c-61ce-4c00-97ca-ddaa2e0cacf6"
             },
             {
               "predicate": "http://www.ft.com/ontology/annotation/about",
               "types": [
                 "http://www.ft.com/ontology/core/Thing",
                 "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/Topic"
+                "http://www.ft.com/ontology/Location"
               ],
-              "apiUrl": "http://api.ft.com/things/b2708390-ac5c-3592-9ab2-b0d09c40398d",
-              "directType": "http://www.ft.com/ontology/Topic",
-              "prefLabel": "Advertising",
-              "id": "b2708390-ac5c-3592-9ab2-b0d09c40398d",
-              "type": "TOPIC",
-              "url": "https://www.ft.com/stream/b2708390-ac5c-3592-9ab2-b0d09c40398d"
+              "apiUrl": "http://api.ft.com/things/01dcc40b-8099-35f2-adbf-637c9b7b160b",
+              "directType": "http://www.ft.com/ontology/Location",
+              "prefLabel": "Simandou",
+              "preposition": "on",
+              "id": "01dcc40b-8099-35f2-adbf-637c9b7b160b",
+              "type": "LOCATION",
+              "relativeUrl": "/stream/01dcc40b-8099-35f2-adbf-637c9b7b160b",
+              "url": "https://www.ft.com/stream/01dcc40b-8099-35f2-adbf-637c9b7b160b"
             },
             {
-              "predicate": "http://www.ft.com/ontology/classification/isClassifiedBy",
+              "predicate": "http://www.ft.com/ontology/annotation/about",
               "types": [
                 "http://www.ft.com/ontology/core/Thing",
                 "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/classification/Classification",
-                "http://www.ft.com/ontology/Section"
+                "http://www.ft.com/ontology/Location"
               ],
-              "apiUrl": "http://api.ft.com/things/852939c8-859c-361e-8514-f82f6c041580",
-              "directType": "http://www.ft.com/ontology/Section",
-              "prefLabel": "Companies",
-              "id": "852939c8-859c-361e-8514-f82f6c041580",
-              "type": "SECTION",
-              "url": "https://www.ft.com/stream/852939c8-859c-361e-8514-f82f6c041580"
+              "apiUrl": "http://api.ft.com/things/0236bde5-98d7-3dd6-8819-e0bc25124595",
+              "directType": "http://www.ft.com/ontology/Location",
+              "prefLabel": "Guinea",
+              "preposition": "on",
+              "id": "0236bde5-98d7-3dd6-8819-e0bc25124595",
+              "type": "LOCATION",
+              "relativeUrl": "/stream/0236bde5-98d7-3dd6-8819-e0bc25124595",
+              "url": "https://www.ft.com/stream/0236bde5-98d7-3dd6-8819-e0bc25124595"
             },
             {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/Topic"
-              ],
-              "apiUrl": "http://api.ft.com/things/9151841f-0686-3531-9486-f89ade98a65d",
-              "directType": "http://www.ft.com/ontology/Topic",
-              "prefLabel": "EU business regulation",
-              "id": "9151841f-0686-3531-9486-f89ade98a65d",
-              "type": "TOPIC",
-              "url": "https://www.ft.com/stream/9151841f-0686-3531-9486-f89ade98a65d"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
+              "predicate": "http://www.ft.com/ontology/implicitlyAbout",
               "types": [
                 "http://www.ft.com/ontology/core/Thing",
                 "http://www.ft.com/ontology/concept/Concept",
                 "http://www.ft.com/ontology/Topic"
               ],
-              "apiUrl": "http://api.ft.com/things/ce93225f-bb29-3a4f-936a-f852dfe740da",
+              "apiUrl": "http://api.ft.com/things/67fb70ae-b970-4bd1-92ea-761618ae8cb7",
               "directType": "http://www.ft.com/ontology/Topic",
-              "prefLabel": "Data protection",
-              "id": "ce93225f-bb29-3a4f-936a-f852dfe740da",
+              "prefLabel": "Natural resources",
+              "preposition": "on",
+              "id": "67fb70ae-b970-4bd1-92ea-761618ae8cb7",
               "type": "TOPIC",
-              "url": "https://www.ft.com/stream/ce93225f-bb29-3a4f-936a-f852dfe740da"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/organisation/Organisation"
-              ],
-              "apiUrl": "http://api.ft.com/organisations/1b4b842d-8bae-3b78-9c50-5a7a0d60e2ef",
-              "directType": "http://www.ft.com/ontology/organisation/Organisation",
-              "prefLabel": "Le Monde Du Regard SAS",
-              "id": "1b4b842d-8bae-3b78-9c50-5a7a0d60e2ef",
-              "type": "ORGANISATION",
-              "url": "https://www.ft.com/stream/1b4b842d-8bae-3b78-9c50-5a7a0d60e2ef"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/majorMentions",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/organisation/Organisation"
-              ],
-              "apiUrl": "http://api.ft.com/organisations/73cc33b5-d0cb-3815-8347-bc49e1ddbd5c",
-              "directType": "http://www.ft.com/ontology/organisation/Organisation",
-              "prefLabel": "The Financial Times Ltd.",
-              "id": "73cc33b5-d0cb-3815-8347-bc49e1ddbd5c",
-              "type": "ORGANISATION",
-              "url": "https://www.ft.com/stream/73cc33b5-d0cb-3815-8347-bc49e1ddbd5c"
-            },
-            {
-              "predicate": "http://www.ft.com/ontology/annotation/hasAuthor",
-              "types": [
-                "http://www.ft.com/ontology/core/Thing",
-                "http://www.ft.com/ontology/concept/Concept",
-                "http://www.ft.com/ontology/person/Person"
-              ],
-              "apiUrl": "http://api.ft.com/people/81fbe64c-155d-3e74-bb40-c6fe829f4d7e",
-              "directType": "http://www.ft.com/ontology/person/Person",
-              "prefLabel": "David Bond",
-              "id": "81fbe64c-155d-3e74-bb40-c6fe829f4d7e",
-              "type": "PERSON",
-              "url": "https://www.ft.com/stream/81fbe64c-155d-3e74-bb40-c6fe829f4d7e"
+              "relativeUrl": "/natural-resources",
+              "url": "https://www.ft.com/natural-resources"
             }
           ]
-        },
-        "sort": [
-          1495983520000
-        ]
+        }
       }
     ]
   }

--- a/test/fixtures/concept-not-found.json
+++ b/test/fixtures/concept-not-found.json
@@ -1,13 +1,17 @@
 {
-  "took": 1,
+  "took": 676,
   "timed_out": false,
   "_shards": {
-    "total": 1,
-    "successful": 1,
+    "total": 4,
+    "successful": 4,
+    "skipped": 0,
     "failed": 0
   },
   "hits": {
-    "total": 0,
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
     "max_score": null,
     "hits": []
   }

--- a/test/fixtures/count.json
+++ b/test/fixtures/count.json
@@ -1,8 +1,9 @@
 {
-  "count": 6044,
+  "count": 866114,
   "_shards": {
     "total": 4,
     "successful": 4,
+    "skipped": 0,
     "failed": 0
   }
 }

--- a/test/fixtures/mget-no-results.json
+++ b/test/fixtures/mget-no-results.json
@@ -1,27 +1,27 @@
 {
   "docs": [
     {
-      "_index": "content_2017-03-22",
-      "_type": "item",
+      "_index": "content_2021-01-27",
+      "_type": "_doc",
       "_id": "ff1f01be-1564-11e7-b0c1-37e417ee6c76",
       "found": false
     },
     {
-      "_index": "content_2017-03-22",
-      "_type": "item",
-      "_id": "ff3d0c6e-153d-11e7-b0c1-37e417ee6c76",
+      "_index": "content_2021-01-27",
+      "_type": "_doc",
+      "_id": "ff1f01be-1564-11e7-b0c1-37e417ee6c76",
       "found": false
     },
     {
-      "_index": "content_2017-03-22",
-      "_type": "item",
-      "_id": "ff90a2d8-148f-11e7-80f4-13e067d5072c",
+      "_index": "content_2021-01-27",
+      "_type": "_doc",
+      "_id": "ff1f01be-1564-11e7-b0c1-37e417ee6c76",
       "found": false
     },
     {
-      "_index": "content_2017-03-22",
-      "_type": "item",
-      "_id": "ff032668-155f-11e7-80f4-13e067d5072c",
+      "_index": "content_2021-01-27",
+      "_type": "_doc",
+      "_id": "ff1f01be-1564-11e7-b0c1-37e417ee6c76",
       "found": false
     }
   ]

--- a/test/fixtures/mget-with-results.json
+++ b/test/fixtures/mget-with-results.json
@@ -1,55 +1,63 @@
 {
   "docs": [
     {
-      "_index": "content_2017-03-22",
-      "_type": "item",
-      "_id": "af1f01be-1564-11e7-b0c1-37e417ee6c76",
-      "_version": 5,
+      "_index": "content_2021-01-27",
+      "_type": "_doc",
+      "_id": "9ef3a1c5-328c-460d-9261-33ea991cae62",
+      "_version": 12,
+      "_seq_no": 1537991,
+      "_primary_term": 1,
       "found": true,
       "_source": {
-        "id": "af1f01be-1564-11e7-b0c1-37e417ee6c76",
-        "publishedDate": "2017-03-30T17:28:35.000Z",
-        "title": "Pupils from wealthy homes tend to earn more",
-        "url": "https://www.ft.com/content/af1f01be-1564-11e7-b0c1-37e417ee6c76"
+        "id": "9ef3a1c5-328c-460d-9261-33ea991cae62",
+        "publishedDate": "2021-02-19T10:43:02.503Z",
+        "title": "Uber loses landmark UK battle as Supreme Court rules drivers are workers",
+        "url": "https://www.ft.com/content/9ef3a1c5-328c-460d-9261-33ea991cae62"
       }
     },
     {
-      "_index": "content_2017-03-22",
-      "_type": "item",
-      "_id": "803d0c6e-153d-11e7-b0c1-37e417ee6c76",
-      "_version": 11,
+      "_index": "content_2021-01-27",
+      "_type": "_doc",
+      "_id": "02ecd3cc-40ee-4712-ae9a-d9b41427d6e9",
+      "_version": 2,
+      "_seq_no": 1508810,
+      "_primary_term": 1,
       "found": true,
       "_source": {
-        "id": "803d0c6e-153d-11e7-b0c1-37e417ee6c76",
-        "publishedDate": "2017-03-30T17:17:42.000Z",
-        "title": "Trump’s leap backwards to the smoggy age of coal",
-        "url": "https://www.ft.com/content/803d0c6e-153d-11e7-b0c1-37e417ee6c76"
+        "id": "02ecd3cc-40ee-4712-ae9a-d9b41427d6e9",
+        "publishedDate": "2021-02-19T03:01:31.191Z",
+        "title": "China’s clampdown on Jack Ma’s Ant boosts rivals",
+        "url": "https://www.ft.com/content/02ecd3cc-40ee-4712-ae9a-d9b41427d6e9"
       }
     },
     {
-      "_index": "content_2017-03-22",
-      "_type": "item",
-      "_id": "2690a2d8-148f-11e7-80f4-13e067d5072c",
-      "_version": 10,
+      "_index": "content_2021-01-27",
+      "_type": "_doc",
+      "_id": "f5c8f565-3463-4a18-b64b-24075d83ad57",
+      "_version": 9,
+      "_seq_no": 1536278,
+      "_primary_term": 1,
       "found": true,
       "_source": {
-        "id": "2690a2d8-148f-11e7-80f4-13e067d5072c",
-        "publishedDate": "2017-03-30T17:15:42.000Z",
-        "title": "Political risk stalks booming Silicon Valley",
-        "url": "https://www.ft.com/content/2690a2d8-148f-11e7-80f4-13e067d5072c"
+        "id": "f5c8f565-3463-4a18-b64b-24075d83ad57",
+        "publishedDate": "2021-02-19T09:51:07.881Z",
+        "title": "G7 leaders put spotlight on vaccine donations to developing world",
+        "url": "https://www.ft.com/content/f5c8f565-3463-4a18-b64b-24075d83ad57"
       }
     },
     {
-      "_index": "content_2017-03-22",
-      "_type": "item",
-      "_id": "6b032668-155f-11e7-80f4-13e067d5072c",
-      "_version": 8,
+      "_index": "content_2021-01-27",
+      "_type": "_doc",
+      "_id": "e1a526ba-f1c8-45df-88f1-9aa32fa4af3e",
+      "_version": 19,
+      "_seq_no": 1536599,
+      "_primary_term": 1,
       "found": true,
       "_source": {
-        "id": "6b032668-155f-11e7-80f4-13e067d5072c",
-        "publishedDate": "2017-03-30T17:12:40.000Z",
-        "title": "VW agrees to pay additional $157m to settle environmental claims",
-        "url": "https://www.ft.com/content/6b032668-155f-11e7-80f4-13e067d5072c"
+        "id": "e1a526ba-f1c8-45df-88f1-9aa32fa4af3e",
+        "publishedDate": "2021-02-19T10:00:46.532Z",
+        "title": "British retail sales fall sharply and more than expected in January ",
+        "url": "https://www.ft.com/content/e1a526ba-f1c8-45df-88f1-9aa32fa4af3e"
       }
     }
   ]

--- a/test/fixtures/msearch-no-results.json
+++ b/test/fixtures/msearch-no-results.json
@@ -1,34 +1,43 @@
 {
+  "took": 9,
   "responses": [
-      {
-          "took": 2,
-          "timed_out": false,
-          "_shards": {
-              "total": 4,
-              "successful": 4,
-              "failed": 0
-          },
-          "hits": {
-              "total": 0,
-              "max_score": null,
-              "hits": []
-          },
-          "status": 200
+    {
+      "took": 2,
+      "timed_out": false,
+      "_shards": {
+        "total": 4,
+        "successful": 4,
+        "skipped": 0,
+        "failed": 0
       },
-      {
-          "took": 1,
-          "timed_out": false,
-          "_shards": {
-              "total": 4,
-              "successful": 4,
-              "failed": 0
+      "hits": {
+        "total": {
+          "value": 0,
+          "relation": "eq"
+        },
+        "max_score": null,
+        "hits": []
+      },
+      "status": 200
+    },
+    {
+        "took": 1,
+        "timed_out": false,
+        "_shards": {
+          "total": 4,
+          "successful": 4,
+          "skipped": 0,
+          "failed": 0
+        },
+        "hits": {
+          "total": {
+            "value": 0,
+            "relation": "eq"
           },
-          "hits": {
-              "total": 0,
-              "max_score": null,
-              "hits": []
-          },
-          "status": 200
-      }
+          "max_score": null,
+          "hits": []
+        },
+        "status": 200
+    }
   ]
 }

--- a/test/fixtures/msearch-with-results.json
+++ b/test/fixtures/msearch-with-results.json
@@ -1,72 +1,81 @@
 {
+  "took": 9,
   "responses": [
-      {
-          "took": 7,
-          "timed_out": false,
-          "_shards": {
-              "total": 4,
-              "successful": 4,
-              "failed": 0
-          },
-          "hits": {
-              "total": 19258,
-              "max_score": null,
-              "hits": [
-                  {
-                      "_index": "content_2018-09-28",
-                      "_type": "item",
-                      "_id": "30364c64-f150-11dc-a91a-0000779fd2ac",
-                      "_score": null,
-                      "_source": {
-                          "title": "Iran’s elite paper over the economic cracks"
-                      }
-                  },
-                  {
-                      "_index": "content_2018-09-28",
-                      "_type": "item",
-                      "_id": "f3ab96be-b72e-11e7-8c12-5661783e5589",
-                      "_score": null,
-                      "_source": {
-                          "title": "US-backed fighters take control of Syria’s largest oilfield"
-                      }
-                  }
-              ]
-          },
-          "status": 200
+    {
+      "took": 7,
+      "timed_out": false,
+      "_shards": {
+        "total": 4,
+        "successful": 4,
+        "skipped": 0,
+        "failed": 0
       },
-      {
-          "took": 7,
-          "timed_out": false,
-          "_shards": {
-              "total": 4,
-              "successful": 4,
-              "failed": 0
+      "hits": {
+        "total": {
+          "value": 19258,
+          "relation": "eq"
+        },
+        "max_score": null,
+        "hits": [
+          {
+            "_index": "content_2018-09-28",
+            "_type": "item",
+            "_id": "30364c64-f150-11dc-a91a-0000779fd2ac",
+            "_score": null,
+            "_source": {
+              "title": "Iran’s elite paper over the economic cracks"
+            }
           },
-          "hits": {
-              "total": 69470,
-              "max_score": null,
-              "hits": [
-                  {
-                      "_index": "content_2018-09-28",
-                      "_type": "item",
-                      "_id": "ab0cf1fa-4fbe-11e7-a1f2-db19572361bb",
-                      "_score": null,
-                      "_source": {
-                          "title": "The battle to keep artists in the capital"
-                      }
-                  },
-                  {
-                      "_index": "content_2018-09-28",
-                      "_type": "item",
-                      "_id": "3ace6a68-efa9-11d9-bd3b-00000e2511c8",
-                      "_score": null,
-                      "_source": {
-                          "title": "Melding art and industry"
-                      }
-                  }
-              ]
+          {
+            "_index": "content_2018-09-28",
+            "_type": "item",
+            "_id": "f3ab96be-b72e-11e7-8c12-5661783e5589",
+            "_score": null,
+            "_source": {
+              "title": "US-backed fighters take control of Syria’s largest oilfield"
+            }
+          }
+        ]
+      },
+      "status": 200
+    },
+    {
+      "took": 7,
+      "timed_out": false,
+      "_shards": {
+        "total": 4,
+        "successful": 4,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": {
+          "value": 69470,
+          "relation": "eq"
+        },
+        "max_score": null,
+        "hits": [
+          {
+            "_index": "content_2018-09-28",
+            "_type": "item",
+            "_id": "ab0cf1fa-4fbe-11e7-a1f2-db19572361bb",
+            "_score": null,
+            "_source": {
+              "title": "The battle to keep artists in the capital"
+            }
           },
-          "status": 200
-      }
+          {
+            "_index": "content_2018-09-28",
+            "_type": "item",
+            "_id": "3ace6a68-efa9-11d9-bd3b-00000e2511c8",
+            "_score": null,
+            "_source": {
+              "title": "Melding art and industry"
+            }
+          }
+        ]
+      },
+      "status": 200
+    }
   ]
 }

--- a/test/fixtures/search-error.json
+++ b/test/fixtures/search-error.json
@@ -3,15 +3,19 @@
     "root_cause": [
       {
         "type": "parsing_exception",
-        "reason": "no [query] registered for [tersm]",
-        "line": 8,
-        "col": 28
+        "reason": "unknown query [filtered]",
+        "line": 3,
+        "col": 14
       }
     ],
     "type": "parsing_exception",
-    "reason": "no [query] registered for [tersm]",
-    "line": 8,
-    "col": 28
+    "reason": "unknown query [filtered]",
+    "line": 3,
+    "col": 14,
+    "caused_by": {
+      "type": "named_object_not_found_exception",
+      "reason": "[3:14] unknown field [filtered]"
+    }
   },
   "status": 400
 }

--- a/test/fixtures/search-no-results.json
+++ b/test/fixtures/search-no-results.json
@@ -2,12 +2,16 @@
   "took": 1,
   "timed_out": false,
   "_shards": {
-    "total": 5,
-    "successful": 5,
+    "total": 4,
+    "successful": 4,
+    "skipped": 0,
     "failed": 0
   },
   "hits": {
-    "total": 0,
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
     "max_score": null,
     "hits": []
   }

--- a/test/fixtures/search-with-results.json
+++ b/test/fixtures/search-with-results.json
@@ -2,12 +2,16 @@
   "took": 17,
   "timed_out": false,
   "_shards": {
-    "total": 5,
-    "successful": 5,
+    "total": 4,
+    "successful": 4,
+    "skipped": 0,
     "failed": 0
   },
   "hits": {
-    "total": 680996,
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
     "max_score": null,
     "hits": [
       {

--- a/test/spec/concept-spec.js
+++ b/test/spec/concept-spec.js
@@ -13,11 +13,11 @@ describe('Concept', () => {
 	});
 
 	context('Response - found', () => {
-		const id = '73cc33b5-d0cb-3815-8347-bc49e1ddbd5c';
+		const id = '80871faa-d16f-4c9f-b310-df42104dcecc';
 
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_search')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_search')
 				.reply(200, fixtureFound);
 		});
 
@@ -51,8 +51,8 @@ describe('Concept', () => {
 		const id = '73cc33b5-d0cb-3815-8347-bg24c232324c';
 
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_search')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_search')
 				.reply(200, fixtureNotFound);
 		});
 
@@ -65,8 +65,8 @@ describe('Concept', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_search')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_search')
 				.reply(500);
 		});
 

--- a/test/spec/count-spec.js
+++ b/test/spec/count-spec.js
@@ -18,8 +18,8 @@ describe('Count', () => {
 				}
 			};
 
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_count', (body) => {
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_count', (body) => {
 					return body.query.term['metadata.idV1'] === 'Ng==-U2VjdGlvbnM=';
 				})
 				.reply(200, fixture);
@@ -30,8 +30,8 @@ describe('Count', () => {
 
 	context('Response - success', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_count')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_count')
 				.reply(200, fixture);
 		});
 
@@ -45,8 +45,8 @@ describe('Count', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_count')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_count')
 				.reply(500);
 		});
 

--- a/test/spec/get-spec.js
+++ b/test/spec/get-spec.js
@@ -13,8 +13,8 @@ describe('Get', () => {
 
 	context('With options', () => {
 		it('accepts a source parameter', () => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.get(`/content/item/${fixture.id}/_source`)
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.get(`/content/_doc/${fixture.id}/_source`)
 				.query((params) => {
 					return params._source === 'id,title';
 				})
@@ -26,8 +26,8 @@ describe('Get', () => {
 
 	context('Response - found', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.get(`/content/item/${fixture.id}/_source`)
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.get(`/content/_doc/${fixture.id}/_source`)
 				.query(true)
 				.reply(200, fixture);
 		});
@@ -41,8 +41,8 @@ describe('Get', () => {
 
 	context('Response - not found', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.get(`/content/item/${fixture.id}/_source`)
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.get(`/content/_doc/${fixture.id}/_source`)
 				.query(true)
 				.reply(404);
 		});

--- a/test/spec/mget-spec.js
+++ b/test/spec/mget-spec.js
@@ -16,8 +16,8 @@ describe('Multi get', () => {
 		it('accepts an IDs parameter', () => {
 			const ids = [123, 456, 789];
 
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_mget', (body) => {
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_mget', (body) => {
 					return body.ids.every((id, i) => id === ids[i]);
 				})
 				.reply(200, fixtureWithResults);
@@ -28,8 +28,8 @@ describe('Multi get', () => {
 		it('accepts a source parameter', () => {
 			const source = 'id,title';
 
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_mget', (body) => {
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_mget', (body) => {
 					return body._source === source;
 				})
 				.reply(200, fixtureWithResults);
@@ -40,8 +40,8 @@ describe('Multi get', () => {
 
 	context('Response - with results', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_mget')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_mget')
 				.reply(200, fixtureWithResults);
 		});
 
@@ -63,8 +63,8 @@ describe('Multi get', () => {
 
 	context('Response - no results', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_mget')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_mget')
 				.reply(200, fixtureNoResults);
 		});
 
@@ -83,8 +83,8 @@ describe('Multi get', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_mget')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_mget')
 				.reply(500);
 		});
 

--- a/test/spec/msearch-spec.js
+++ b/test/spec/msearch-spec.js
@@ -15,8 +15,8 @@ describe('msearch', () => {
 
 	context('With options', () => {
 		it('formats each header and query onto a line', () => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_msearch', (body) => {
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_msearch', (body) => {
 					const lines = body.split(/\n/).map(JSON.parse);
 
 					expect(lines.length).to.equal(4);
@@ -32,8 +32,8 @@ describe('msearch', () => {
 		});
 
 		it('sets defaults for each query', () => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_msearch', (body) => {
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_msearch', (body) => {
 					const lines = body.split(/\n/).map(JSON.parse);
 
 					expect(lines[1]).to.include.keys('query', 'from', 'size', 'sort');
@@ -52,8 +52,8 @@ describe('msearch', () => {
 
 	context('Response - with results', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_msearch')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_msearch')
 				.reply(200, fixtureWithResults);
 		});
 
@@ -76,7 +76,7 @@ describe('msearch', () => {
 			subject().then((result) => {
 				result.forEach((item, i) => {
 					const fixtureResponse = fixtureWithResults.responses[i];
-					expect(item.total).to.equal(fixtureResponse.hits.total);
+					expect(item.total).to.equal(fixtureResponse.hits.total.value);
 				});
 			})
 		));
@@ -94,8 +94,8 @@ describe('msearch', () => {
 
 	context('Response - no results', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_msearch')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_msearch')
 				.reply(200, fixtureNoResults);
 		});
 
@@ -116,8 +116,8 @@ describe('msearch', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_msearch')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_msearch')
 				.reply(400, fixtureError);
 		});
 

--- a/test/spec/search-spec.js
+++ b/test/spec/search-spec.js
@@ -18,8 +18,8 @@ describe('Search', () => {
 			const from = 10;
 			const size = 20;
 
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_search', (body) => {
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_search', (body) => {
 					return body.from === from && body.size === size;
 				})
 				.reply(200, fixtureWithResults);
@@ -30,8 +30,8 @@ describe('Search', () => {
 		it('accepts a source parameter', () => {
 			const source = 'id,title';
 
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_search', (body) => {
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_search', (body) => {
 					return body._source === source;
 				})
 				.reply(200, fixtureWithResults);
@@ -42,8 +42,8 @@ describe('Search', () => {
 
 	context('Response - with results', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_search')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_search')
 				.reply(200, fixtureWithResults);
 		});
 
@@ -56,7 +56,7 @@ describe('Search', () => {
 
 		it('returns the total', () => (
 			subject().then((result) => {
-				expect(result.total).to.equal(fixtureWithResults.hits.total);
+				expect(result.total).to.equal(fixtureWithResults.hits.total.value);
 			})
 		));
 
@@ -71,8 +71,8 @@ describe('Search', () => {
 
 	context('Response - no results', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_search')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_search')
 				.reply(200, fixtureNoResults);
 		});
 
@@ -91,8 +91,8 @@ describe('Search', () => {
 
 	context('Response - error', () => {
 		beforeEach(() => {
-			nock('https://next-elasticsearch.nlb.ft.com')
-				.post('/content/item/_search')
+			nock('https://next-elasticsearch-v7.gslb.ft.com')
+				.post('/content/_search')
 				.reply(400, fixtureError);
 		});
 


### PR DESCRIPTION
This PR applies changes required to migrate from the Elasticsearch v5 cluster to the new v7 one.

There are some required changes to accommodate:
- API URL routes
- Elasticsearch response structure for the `hits` total (see below)
- Fixtures have been updated to use actual responses from Elasticsearch v7

The plan is to merge this and then do a major release.

### Changes in Elasticsearch response structure
#### v5:
```
{
  "hits": {
    "total": 692426,
    …
  },
  …
}
```

#### v7:
```
{
  "hits": {
    "total": {
      "value": 692426,
      "relation": "gte"
    },
    …
  },
  …
}
```