### PR TITLE
Fix msearch request body format

### DIFF
--- a/lib/msearch.js
+++ b/lib/msearch.js
@@ -29,7 +29,7 @@ function search (queries = [], timeout = 3000, dataHandler = handleData) {
 		return accumulator;
 	}, []);
 
-	const body = lines.map(JSON.stringify).join('\n');
+	const body = lines.map(JSON.stringify).join('\n') + '\n';
 
 	return signedFetch('https://next-elasticsearch-v7.gslb.ft.com/content/_msearch', {
 		body,

--- a/test/spec/msearch-spec.js
+++ b/test/spec/msearch-spec.js
@@ -17,7 +17,7 @@ describe('msearch', () => {
 		it('formats each header and query onto a line', () => {
 			nock('https://next-elasticsearch-v7.gslb.ft.com')
 				.post('/content/_msearch', (body) => {
-					const lines = body.split(/\n/).map(JSON.parse);
+					const lines = body.split(/\n/).filter(Boolean).map(JSON.parse);
 
 					expect(lines.length).to.equal(4);
 
@@ -34,7 +34,7 @@ describe('msearch', () => {
 		it('sets defaults for each query', () => {
 			nock('https://next-elasticsearch-v7.gslb.ft.com')
 				.post('/content/_msearch', (body) => {
-					const lines = body.split(/\n/).map(JSON.parse);
+					const lines = body.split(/\n/).filter(Boolean).map(JSON.parse);
 
 					expect(lines[1]).to.include.keys('query', 'from', 'size', 'sort');
 					expect(lines[3]).to.include.keys('query', 'from', 'size', 'sort');


### PR DESCRIPTION
Without this fix we get the following error in response:

- status: 400
- type: llegal_argument_exception
- reason: The msearch request must be terminated by a newline [\n]

This could be a difference between ElasticSearch v5 and v7 we didn't pick up or this never worked... I don't know.