### PR TITLE
[CI-669] Configure CI to wait for approval for renovate PRs on our repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
           requires:
             - test
 
-  renovate-nori-build-test-provision: 
+  renovate-nori-build-test-provision:
     jobs:
       - waiting-for-approval:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,10 @@ references:
     branches:
       only: main
 
+  filters_ignore_main: &filters_ignore_main
+    branches:
+      ignore: main
+
   filters_ignore_tags: &filters_ignore_tags
     tags:
       ignore: /.*/
@@ -45,16 +49,6 @@ references:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
     branches:
       ignore: /.*/
-
-  filters_only_renovate_nori: &filters_only_renovate_nori
-    branches:
-      only: /(^renovate-.*|^nori/.*)/
-
-  filters_ignore_main_tags_renovate_nori: &filters_ignore_main_tags_renovate_nori
-    tags:
-      ignore: /.*/
-    branches:
-      ignore: /(^renovate-.*|^nori/.*|^main)/
 
 version: 2.1
 
@@ -131,7 +125,7 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_ignore_main_tags_renovate_nori
+            <<: *filters_ignore_tags
       - test:
           requires:
             - build
@@ -152,22 +146,6 @@ workflows:
             <<: *filters_version_tag
           requires:
             - test
-
-  renovate-nori-build-test-provision:
-    jobs:
-      - waiting-for-approval:
-          type: approval
-          filters:
-            <<: *filters_only_renovate_nori
-      - build:
-          requires:
-            - waiting-for-approval
-      - test:
-          requires:
-            - build
-      - provision:
-          requires:
-            - build
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
           requires:
             - test
 
-  renovate-nori-build-test-provision:
+  renovate-nori-build-test-provision: 
     jobs:
       - waiting-for-approval:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,6 @@ references:
     branches:
       only: main
 
-  filters_ignore_main: &filters_ignore_main
-    branches:
-      ignore: main
-
   filters_ignore_tags: &filters_ignore_tags
     tags:
       ignore: /.*/
@@ -49,6 +45,16 @@ references:
         - /^v?\d+\.\d+\.\d+(?:-beta\.\d+)?$/
     branches:
       ignore: /.*/
+
+  filters_only_renovate_nori: &filters_only_renovate_nori
+    branches:
+      only: /(^renovate-.*|^nori/.*)/
+
+  filters_ignore_main_tags_renovate_nori: &filters_ignore_main_tags_renovate_nori
+    tags:
+      ignore: /.*/
+    branches:
+      ignore: /(^renovate-.*|^nori/.*|^main)/
 
 version: 2.1
 
@@ -125,7 +131,7 @@ workflows:
     jobs:
       - build:
           filters:
-            <<: *filters_ignore_tags
+            <<: *filters_ignore_main_tags_renovate_nori
       - test:
           requires:
             - build
@@ -146,6 +152,22 @@ workflows:
             <<: *filters_version_tag
           requires:
             - test
+
+  renovate-nori-build-test-provision:
+    jobs:
+      - waiting-for-approval:
+          type: approval
+          filters:
+            <<: *filters_only_renovate_nori
+      - build:
+          requires:
+            - waiting-for-approval
+      - test:
+          requires:
+            - build
+      - provision:
+          requires:
+            - build
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,9 +165,6 @@ workflows:
       - test:
           requires:
             - build
-      - provision:
-          requires:
-            - build
 
   nightly:
     triggers:


### PR DESCRIPTION
Configure CI to wait for approval for renovate PRs on our repos

[https://financialtimes.atlassian.net/browse/CI-669](https://financialtimes.atlassian.net/browse/CI-669)