### PR TITLE
[CI-669] Remove main from ignored branches in Circle CI waiting-for-approval configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ references:
     tags:
       ignore: /.*/
     branches:
-      ignore: /(^renovate-.*|^nori/.*|^main)/
+      ignore: /(^renovate-.*|^nori/.*)/
 
 version: 2.1
 


### PR DESCRIPTION
Remove main from ignored branches in Circle CI waiting-for-approval configuration

[https://financialtimes.atlassian.net/browse/CI-669](https://financialtimes.atlassian.net/browse/CI-669)