### PR TITLE
change build-tes-provision in order to need approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ references:
     branches:
       only: /(^renovate-.*|^nori/.*)/
 
-  filters_ignore_main_tags_renovate_nori: &filters_ignore_main_tags_renovate_nori
+  filters_ignore_tags_renovate_nori_main: &filters_ignore_tags_renovate_nori_main
     tags:
       ignore: /.*/
     branches:
@@ -145,16 +145,34 @@ workflows:
   build-test:
     jobs:
       - build:
+          name: build-no-main-v<< matrix.node-version >>
           filters:
-            <<: *filters_ignore_main_tags_renovate_nori
-          name: build-v<< matrix.node-version >>
+            <<: *filters_ignore_tags_renovate_nori_main
           matrix:
             parameters:
               node-version: [ "16.14", "14.19" ]
       - test:
+          name : test-no-main-v<< matrix.node-version >>
           requires:
-            - build-v<< matrix.node-version >>
-          name: test-v<< matrix.node-version >>
+            - build-no-main-v<< matrix.node-version >>
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
+      - wait-for-approval:
+          type: approval
+          filters:
+            <<: *filters_only_renovate_nori
+      - build:
+          name: build-renovate-v<< matrix.node-version >>
+          requires:
+            - wait-for-approval
+          matrix:
+            parameters:
+              node-version: [ "16.14", "14.19" ]
+      - test:
+          name : test-renovate-v<< matrix.node-version >>
+          requires:
+            - build-renovate-v<< matrix.node-version >>
           matrix:
             parameters:
               node-version: [ "16.14", "14.19" ]
@@ -183,19 +201,6 @@ workflows:
             <<: *filters_version_tag
           requires:
             - test-v16.14
-
-  renovate-nori-build-test-provision:
-    jobs:
-      - waiting-for-approval:
-          type: approval
-          filters:
-            <<: *filters_only_renovate_nori
-      - build:
-          requires:
-            - waiting-for-approval
-      - test:
-          requires:
-            - build
 
   nightly:
     triggers:


### PR DESCRIPTION
There is an error with the required steps and the configuration on circleCi config.yml that it doesn't allow to merge into main due that build-test-provision job is required . This job should continue to be required in order to guarantee the PR stability.
From Github settings i haven't found a way to only required build-test in some PR an others no , so I've got the solution changing the way we were making the approval for renovate/nori branches.
Instead of creating a new job only for this PRs i have integrated the logic of approval inside the build-test job so always is launched an Github would allows us to merge into main without changing the old behavior
[ticket](https://financialtimes.atlassian.net/browse/CI-1103)