### PR TITLE
Require n-logger v10.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@financial-times/n-logger": "^6.0.0",
+        "@financial-times/n-logger": "^10.2.0",
         "http-errors": "^1.8.0",
         "signed-aws-es-fetch": "^1.4.0"
       },
@@ -538,16 +538,18 @@
       }
     },
     "node_modules/@financial-times/n-logger": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.2.0.tgz",
-      "integrity": "sha512-FTzinevWoQ/co6wQ16mCluJ5FfqaeSIZG1bvsphXLnEaGN5P5LeWd3ytTljAf85qlP/If4tcgqDd8Uhf7EWRuA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
+      "integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
+      "hasInstallScript": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
         "node-fetch": "^2.6.0",
         "winston": "^2.4.0"
       },
       "engines": {
-        "node": ">=6.1.0"
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/n-logger/node_modules/node-fetch": {
@@ -11595,9 +11597,9 @@
       }
     },
     "@financial-times/n-logger": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-6.2.0.tgz",
-      "integrity": "sha512-FTzinevWoQ/co6wQ16mCluJ5FfqaeSIZG1bvsphXLnEaGN5P5LeWd3ytTljAf85qlP/If4tcgqDd8Uhf7EWRuA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
+      "integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-es-client",
   "dependencies": {
-    "@financial-times/n-logger": "^6.0.0",
+    "@financial-times/n-logger": "^10.2.0",
     "http-errors": "^1.8.0",
     "signed-aws-es-fetch": "^1.4.0"
   },


### PR DESCRIPTION
n-logger v10.2.0 adds in the ability to switch to Heroku log drains
rather than sending logs to Splunk manually. In order to support this
feature we need to limit the version range to be v10.2.0 or above
otherwise the feature will be present inconsistently.

This is not a breaking change because the major versions of n-logger
between 6 and 10 have no impact on this package:

  - v7.0.0 of n-logger only supports Node.js 14+ (no change for us)
  - v8.0.0 of n-logger re-adds support for Node.js 12
  - v9.0.0 of n-logger deprecates the SYSTEM_CODE environment variable
    (but then undeprecates it in v9.0.1)
  - v10.0.0 of n-logger only supports Node.js 14+ (no change for us)