### PR TITLE
Breaking: replace n-logger with Reliability Kit logger

### DIFF
--- a/lib/helpers/get-endpoint.js
+++ b/lib/helpers/get-endpoint.js
@@ -1,4 +1,4 @@
-const logger = require('@financial-times/n-logger').default;
+const logger = require('@dotcom-reliability-kit/logger');
 
 const endpoints = {
 	development: 'https://search-next-elasticsearch-v7-dev-znli3en2mvhur6j35qsr4673fq.eu-west-1.es.amazonaws.com',

--- a/lib/helpers/handle-response.js
+++ b/lib/helpers/handle-response.js
@@ -1,5 +1,5 @@
 const httpError = require('http-errors');
-const logger = require('@financial-times/n-logger').default;
+const logger = require('@dotcom-reliability-kit/logger');
 
 function handleResponse(response) {
 	if (response.ok) {

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,4 +1,4 @@
-const logger = require('@financial-times/n-logger').default;
+const logger = require('@dotcom-reliability-kit/logger');
 
 module.exports = () => {
 	logger.error('DEPRECATED: The `tag` method of n-es-client is obsolete.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0",
 			"hasInstallScript": true,
 			"dependencies": {
-				"@financial-times/n-logger": "^10.2.0",
+				"@dotcom-reliability-kit/logger": "^2.2.6",
 				"http-errors": "^1.8.0",
 				"signed-aws-es-fetch": "^1.4.0"
 			},
@@ -110,6 +110,42 @@
 				"colorspace": "1.1.x",
 				"enabled": "2.0.x",
 				"kuler": "^2.0.0"
+			}
+		},
+		"node_modules/@dotcom-reliability-kit/app-info": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+			"integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw==",
+			"engines": {
+				"node": "16.x || 18.x || 20.x",
+				"npm": "7.x || 8.x || 9.x"
+			}
+		},
+		"node_modules/@dotcom-reliability-kit/logger": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.6.tgz",
+			"integrity": "sha512-t1gPmyfdDnwfHymVcMEy8K7EEBeZTl73XtUyoRV3BZwnj06T0quHLdY1ZwidvyPG2lISTjc3bFuRUTGoUWtS7g==",
+			"dependencies": {
+				"@dotcom-reliability-kit/app-info": "^2.1.0",
+				"@dotcom-reliability-kit/serialize-error": "^2.1.0",
+				"lodash.clonedeep": "^4.5.0",
+				"pino": "^8.14.1"
+			},
+			"engines": {
+				"node": "16.x || 18.x || 20.x",
+				"npm": "7.x || 8.x || 9.x"
+			},
+			"peerDependencies": {
+				"pino-pretty": ">=7.0.0 <11.0.0"
+			}
+		},
+		"node_modules/@dotcom-reliability-kit/serialize-error": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+			"integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q==",
+			"engines": {
+				"node": "16.x || 18.x || 20.x",
+				"npm": "7.x || 8.x || 9.x"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/circleci": {
@@ -867,40 +903,6 @@
 				"npm": "7.x || 8.x"
 			}
 		},
-		"node_modules/@financial-times/n-logger": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
-			"integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
-			"hasInstallScript": true,
-			"dependencies": {
-				"json-stringify-safe": "^5.0.1",
-				"node-fetch": "^2.6.0",
-				"winston": "^2.4.0"
-			},
-			"engines": {
-				"node": "14.x || 16.x",
-				"npm": "7.x || 8.x"
-			}
-		},
-		"node_modules/@financial-times/n-logger/node_modules/node-fetch": {
-			"version": "2.6.7",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@financial-times/package-json": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@financial-times/package-json/-/package-json-3.0.0.tgz",
@@ -1245,6 +1247,17 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
@@ -1471,16 +1484,19 @@
 				"node": "*"
 			}
 		},
-		"node_modules/async": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-			"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
-		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
+		},
+		"node_modules/atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+			"engines": {
+				"node": ">=8.0.0"
+			}
 		},
 		"node_modules/aws-sign2": {
 			"version": "0.7.0",
@@ -1499,8 +1515,26 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -1553,6 +1587,29 @@
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
 		},
 		"node_modules/builtins": {
 			"version": "1.0.3",
@@ -1985,6 +2042,12 @@
 				"color-support": "bin.js"
 			}
 		},
+		"node_modules/colorette": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+			"peer": true
+		},
 		"node_modules/colors": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -2131,14 +2194,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/cycle": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2149,6 +2204,15 @@
 			},
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/dateformat": {
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+			"integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+			"peer": true,
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/debug": {
@@ -2354,6 +2418,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"peer": true,
+			"dependencies": {
+				"once": "^1.4.0"
 			}
 		},
 		"node_modules/env-paths": {
@@ -2954,6 +3027,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
 		"node_modules/extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2969,13 +3058,11 @@
 				"node >=0.6.0"
 			]
 		},
-		"node_modules/eyes": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-			"engines": {
-				"node": "> 0.1.90"
-			}
+		"node_modules/fast-copy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+			"integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+			"peer": true
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -3010,6 +3097,20 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"node_modules/fast-redact": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+			"integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.13.0",
@@ -3143,8 +3244,7 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
@@ -3538,6 +3638,56 @@
 				"he": "bin/he"
 			}
 		},
+		"node_modules/help-me": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+			"integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+			"peer": true,
+			"dependencies": {
+				"glob": "^8.0.0",
+				"readable-stream": "^3.6.0"
+			}
+		},
+		"node_modules/help-me/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/help-me/node_modules/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"peer": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/help-me/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/hook-std": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
@@ -3634,6 +3784,25 @@
 				"url": "https://github.com/sponsors/typicode"
 			}
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/ignore": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -3690,7 +3859,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -4034,7 +4202,8 @@
 		"node_modules/isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"node_modules/iterate-iterator": {
 			"version": "1.0.2",
@@ -4056,6 +4225,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/joycon": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+			"integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/js-tokens": {
@@ -4110,7 +4288,8 @@
 		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"node_modules/jsonc-parser": {
 			"version": "3.1.0",
@@ -4290,6 +4469,11 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
+		},
+		"node_modules/lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
 		},
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
@@ -4473,8 +4657,7 @@
 		"node_modules/minimist": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"node_modules/minipass": {
 			"version": "3.3.4",
@@ -9210,11 +9393,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/on-exit-leak-free": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+			"integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -9454,6 +9641,109 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
+		"node_modules/pino": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-8.15.0.tgz",
+			"integrity": "sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0",
+				"fast-redact": "^3.1.1",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "v1.0.0",
+				"pino-std-serializers": "^6.0.0",
+				"process-warning": "^2.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"sonic-boom": "^3.1.0",
+				"thread-stream": "^2.0.0"
+			},
+			"bin": {
+				"pino": "bin.js"
+			}
+		},
+		"node_modules/pino-abstract-transport": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+			"integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+			"dependencies": {
+				"readable-stream": "^4.0.0",
+				"split2": "^4.0.0"
+			}
+		},
+		"node_modules/pino-abstract-transport/node_modules/readable-stream": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+			"integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/pino-pretty": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.0.tgz",
+			"integrity": "sha512-tRvpyEmGtc2D+Lr3FulIZ+R1baggQ4S3xD2Ar93KixFEDx6SEAUP3W5aYuEw1C73d6ROrNcB2IXLteW8itlwhA==",
+			"peer": true,
+			"dependencies": {
+				"colorette": "^2.0.7",
+				"dateformat": "^4.6.3",
+				"fast-copy": "^3.0.0",
+				"fast-safe-stringify": "^2.1.1",
+				"help-me": "^4.0.1",
+				"joycon": "^3.1.1",
+				"minimist": "^1.2.6",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^1.0.0",
+				"pump": "^3.0.0",
+				"readable-stream": "^4.0.0",
+				"secure-json-parse": "^2.4.0",
+				"sonic-boom": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			},
+			"bin": {
+				"pino-pretty": "bin.js"
+			}
+		},
+		"node_modules/pino-pretty/node_modules/readable-stream": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+			"integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+			"peer": true,
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/pino-pretty/node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/pino-std-serializers": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+			"integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9477,6 +9767,19 @@
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
+		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/process-warning": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+			"integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
 		},
 		"node_modules/promise-inflight": {
 			"version": "1.0.1",
@@ -9542,6 +9845,16 @@
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
+		"node_modules/pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"peer": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"node_modules/punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -9580,6 +9893,11 @@
 				}
 			]
 		},
+		"node_modules/quick-format-unescaped": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -9606,7 +9924,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -9626,6 +9943,14 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
+			}
+		},
+		"node_modules/real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+			"engines": {
+				"node": ">= 12.13.0"
 			}
 		},
 		"node_modules/reduce-flatten": {
@@ -9797,7 +10122,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -9817,7 +10141,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
 			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9833,6 +10156,12 @@
 			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
 			"deprecated": "This package has been deprecated in favour of @sinonjs/samsam",
 			"dev": true
+		},
+		"node_modules/secure-json-parse": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+			"integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+			"peer": true
 		},
 		"node_modules/semver": {
 			"version": "7.3.2",
@@ -10006,6 +10335,14 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/sonic-boom": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+			"integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+			"dependencies": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
 		"node_modules/spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -10037,6 +10374,14 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
 			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
 			"dev": true
+		},
+		"node_modules/split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"engines": {
+				"node": ">= 10.x"
+			}
 		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
@@ -10085,6 +10430,7 @@
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
 			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"dev": true,
 			"engines": {
 				"node": "*"
 			}
@@ -10101,7 +10447,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -10265,6 +10610,14 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
+		"node_modules/thread-stream": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+			"integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+			"dependencies": {
+				"real-require": "^0.2.0"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10301,7 +10654,8 @@
 		"node_modules/tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"node_modules/triple-beam": {
 			"version": "1.3.0",
@@ -10420,8 +10774,7 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"node_modules/uuid": {
 			"version": "3.4.0",
@@ -10512,12 +10865,14 @@
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"dev": true
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"dev": true,
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
@@ -10566,22 +10921,6 @@
 				"string-width": "^1.0.2 || 2"
 			}
 		},
-		"node_modules/winston": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
-			"integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
-			"dependencies": {
-				"async": "~1.0.0",
-				"colors": "1.0.x",
-				"cycle": "1.0.x",
-				"eyes": "0.1.x",
-				"isstream": "0.1.x",
-				"stack-trace": "0.0.x"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			}
-		},
 		"node_modules/winston-transport": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
@@ -10594,14 +10933,6 @@
 			},
 			"engines": {
 				"node": ">= 6.4.0"
-			}
-		},
-		"node_modules/winston/node_modules/colors": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-			"engines": {
-				"node": ">=0.1.90"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -10729,8 +11060,7 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
@@ -11041,6 +11371,27 @@
 				"enabled": "2.0.x",
 				"kuler": "^2.0.0"
 			}
+		},
+		"@dotcom-reliability-kit/app-info": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-2.1.0.tgz",
+			"integrity": "sha512-u7QicgkUbN58IMywvXmNuXxMK5bHUKfjeDC6s3u7TQg5uTGNicdrpBb8zB2O5K++g5KIlVnAafPcJct3ct9Nfw=="
+		},
+		"@dotcom-reliability-kit/logger": {
+			"version": "2.2.6",
+			"resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-2.2.6.tgz",
+			"integrity": "sha512-t1gPmyfdDnwfHymVcMEy8K7EEBeZTl73XtUyoRV3BZwnj06T0quHLdY1ZwidvyPG2lISTjc3bFuRUTGoUWtS7g==",
+			"requires": {
+				"@dotcom-reliability-kit/app-info": "^2.1.0",
+				"@dotcom-reliability-kit/serialize-error": "^2.1.0",
+				"lodash.clonedeep": "^4.5.0",
+				"pino": "^8.14.1"
+			}
+		},
+		"@dotcom-reliability-kit/serialize-error": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-2.1.0.tgz",
+			"integrity": "sha512-JYgnyvds/FZ0KJVRtOAsk9skue5i/vDBkRvQQg5Q/xlbwLdeUSAtD3XXBtlaohHov8kY7/I9UaXcoG6zXZ3a5Q=="
 		},
 		"@dotcom-tool-kit/circleci": {
 			"version": "2.1.4",
@@ -11609,26 +11960,6 @@
 				"eslint-plugin-no-only-tests": ">=2.0.0"
 			}
 		},
-		"@financial-times/n-logger": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
-			"integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
-			"requires": {
-				"json-stringify-safe": "^5.0.1",
-				"node-fetch": "^2.6.0",
-				"winston": "^2.4.0"
-			},
-			"dependencies": {
-				"node-fetch": {
-					"version": "2.6.7",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-					"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-					"requires": {
-						"whatwg-url": "^5.0.0"
-					}
-				}
-			}
-		},
 		"@financial-times/package-json": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@financial-times/package-json/-/package-json-3.0.0.tgz",
@@ -11908,6 +12239,14 @@
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true
 		},
+		"abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"requires": {
+				"event-target-shim": "^5.0.0"
+			}
+		},
 		"acorn": {
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
@@ -12079,16 +12418,16 @@
 			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
 			"dev": true
 		},
-		"async": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-			"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
-		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
+		},
+		"atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -12104,8 +12443,12 @@
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -12152,6 +12495,15 @@
 			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
 			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
 			"dev": true
+		},
+		"buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
 		},
 		"builtins": {
 			"version": "1.0.3",
@@ -12500,6 +12852,12 @@
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true
 		},
+		"colorette": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+			"peer": true
+		},
 		"colors": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -12617,11 +12975,6 @@
 				}
 			}
 		},
-		"cycle": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -12630,6 +12983,12 @@
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
+		},
+		"dateformat": {
+			"version": "4.6.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+			"integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+			"peer": true
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -12788,6 +13147,15 @@
 						"safer-buffer": ">= 2.1.2 < 3.0.0"
 					}
 				}
+			}
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"peer": true,
+			"requires": {
+				"once": "^1.4.0"
 			}
 		},
 		"env-paths": {
@@ -13217,6 +13585,16 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+		},
+		"events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -13229,10 +13607,11 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"dev": true
 		},
-		"eyes": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+		"fast-copy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
+			"integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+			"peer": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -13264,6 +13643,17 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"fast-redact": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.3.0.tgz",
+			"integrity": "sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ=="
+		},
+		"fast-safe-stringify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+			"integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+			"peer": true
 		},
 		"fastq": {
 			"version": "1.13.0",
@@ -13373,8 +13763,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.3.2",
@@ -13660,6 +14049,49 @@
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
 		},
+		"help-me": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/help-me/-/help-me-4.2.0.tgz",
+			"integrity": "sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==",
+			"peer": true,
+			"requires": {
+				"glob": "^8.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"peer": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"glob": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+					"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+					"peer": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^5.0.1",
+						"once": "^1.3.0"
+					}
+				},
+				"minimatch": {
+					"version": "5.1.6",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+					"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+					"peer": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				}
+			}
+		},
 		"hook-std": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
@@ -13731,6 +14163,11 @@
 			"integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
 			"dev": true
 		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+		},
 		"ignore": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -13772,7 +14209,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -14006,7 +14442,8 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"iterate-iterator": {
 			"version": "1.0.2",
@@ -14023,6 +14460,12 @@
 				"es-get-iterator": "^1.0.2",
 				"iterate-iterator": "^1.0.1"
 			}
+		},
+		"joycon": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+			"integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+			"peer": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -14073,7 +14516,8 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"jsonc-parser": {
 			"version": "3.1.0",
@@ -14219,6 +14663,11 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
 		},
 		"lodash.get": {
 			"version": "4.4.2",
@@ -14377,8 +14826,7 @@
 		"minimist": {
 			"version": "1.2.6",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"minipass": {
 			"version": "3.3.4",
@@ -17892,11 +18340,15 @@
 				"es-abstract": "^1.19.1"
 			}
 		},
+		"on-exit-leak-free": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+			"integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -18080,6 +18532,95 @@
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true
 		},
+		"pino": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-8.15.0.tgz",
+			"integrity": "sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==",
+			"requires": {
+				"atomic-sleep": "^1.0.0",
+				"fast-redact": "^3.1.1",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "v1.0.0",
+				"pino-std-serializers": "^6.0.0",
+				"process-warning": "^2.0.0",
+				"quick-format-unescaped": "^4.0.3",
+				"real-require": "^0.2.0",
+				"safe-stable-stringify": "^2.3.1",
+				"sonic-boom": "^3.1.0",
+				"thread-stream": "^2.0.0"
+			}
+		},
+		"pino-abstract-transport": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+			"integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+			"requires": {
+				"readable-stream": "^4.0.0",
+				"split2": "^4.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "4.4.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+					"integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+					"requires": {
+						"abort-controller": "^3.0.0",
+						"buffer": "^6.0.3",
+						"events": "^3.3.0",
+						"process": "^0.11.10",
+						"string_decoder": "^1.3.0"
+					}
+				}
+			}
+		},
+		"pino-pretty": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.2.0.tgz",
+			"integrity": "sha512-tRvpyEmGtc2D+Lr3FulIZ+R1baggQ4S3xD2Ar93KixFEDx6SEAUP3W5aYuEw1C73d6ROrNcB2IXLteW8itlwhA==",
+			"peer": true,
+			"requires": {
+				"colorette": "^2.0.7",
+				"dateformat": "^4.6.3",
+				"fast-copy": "^3.0.0",
+				"fast-safe-stringify": "^2.1.1",
+				"help-me": "^4.0.1",
+				"joycon": "^3.1.1",
+				"minimist": "^1.2.6",
+				"on-exit-leak-free": "^2.1.0",
+				"pino-abstract-transport": "^1.0.0",
+				"pump": "^3.0.0",
+				"readable-stream": "^4.0.0",
+				"secure-json-parse": "^2.4.0",
+				"sonic-boom": "^3.0.0",
+				"strip-json-comments": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "4.4.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+					"integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+					"peer": true,
+					"requires": {
+						"abort-controller": "^3.0.0",
+						"buffer": "^6.0.3",
+						"events": "^3.3.0",
+						"process": "^0.11.10",
+						"string_decoder": "^1.3.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+					"peer": true
+				}
+			}
+		},
+		"pino-std-serializers": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+			"integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+		},
 		"prelude-ls": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -18091,6 +18632,16 @@
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
 			"integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
 			"dev": true
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
+		},
+		"process-warning": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+			"integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -18143,6 +18694,16 @@
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"peer": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -18160,6 +18721,11 @@
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
+		},
+		"quick-format-unescaped": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+			"integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
 		},
 		"randombytes": {
 			"version": "2.1.0",
@@ -18184,7 +18750,6 @@
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -18199,6 +18764,11 @@
 			"requires": {
 				"picomatch": "^2.2.1"
 			}
+		},
+		"real-require": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+			"integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
 		},
 		"reduce-flatten": {
 			"version": "2.0.0",
@@ -18314,14 +18884,12 @@
 		"safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"safe-stable-stringify": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
-			"dev": true
+			"integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -18333,6 +18901,12 @@
 			"resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
 			"integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
 			"dev": true
+		},
+		"secure-json-parse": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+			"integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+			"peer": true
 		},
 		"semver": {
 			"version": "7.3.2",
@@ -18473,6 +19047,14 @@
 				"socks": "^2.6.2"
 			}
 		},
+		"sonic-boom": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+			"integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+			"requires": {
+				"atomic-sleep": "^1.0.0"
+			}
+		},
 		"spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -18504,6 +19086,11 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
 			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
 			"dev": true
+		},
+		"split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
@@ -18540,7 +19127,8 @@
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"dev": true
 		},
 		"statuses": {
 			"version": "1.5.0",
@@ -18551,7 +19139,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
 			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.2.0"
 			}
@@ -18693,6 +19280,14 @@
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
 			"dev": true
 		},
+		"thread-stream": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+			"integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+			"requires": {
+				"real-require": "^0.2.0"
+			}
+		},
 		"to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -18720,7 +19315,8 @@
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+			"dev": true
 		},
 		"triple-beam": {
 			"version": "1.3.0",
@@ -18818,8 +19414,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
 			"version": "3.4.0",
@@ -18903,12 +19498,14 @@
 		"webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+			"dev": true
 		},
 		"whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+			"dev": true,
 			"requires": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
@@ -18949,26 +19546,6 @@
 			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
-			}
-		},
-		"winston": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
-			"integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
-			"requires": {
-				"async": "~1.0.0",
-				"colors": "1.0.x",
-				"cycle": "1.0.x",
-				"eyes": "0.1.x",
-				"isstream": "0.1.x",
-				"stack-trace": "0.0.x"
-			},
-			"dependencies": {
-				"colors": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-				}
 			}
 		},
 		"winston-transport": {
@@ -19076,8 +19653,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"homepage": "https://github.com/Financial-Times/n-es-client",
 	"dependencies": {
-		"@financial-times/n-logger": "^10.2.0",
+		"@dotcom-reliability-kit/logger": "^2.2.6",
 		"http-errors": "^1.8.0",
 		"signed-aws-es-fetch": "^1.4.0"
 	},


### PR DESCRIPTION
This replaces n-logger usage with Reliability Kit logger. It's a breaking change because the module now logs to `stdout` rather than sending logs directly to Splunk. This should be a safe upgrade for most Customer Products apps.