### PR TITLE
ci-2692 node upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,10 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:18.16-browsers
+      - image: cimg/node:20.19
+  node22_14:
+    docker:
+      - image: cimg/node:22.14
 jobs:
   checkout:
     docker:
@@ -26,50 +29,46 @@ workflows:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
-      - waiting-for-approval:
-          type: approval
-          filters:
-            branches:
-              only: /(^renovate-.*|^nori/.*)/
       - tool-kit/setup:
           name: tool-kit/setup-<< matrix.executor >>
-          requires:
-            - checkout
-            - waiting-for-approval
           matrix:
             parameters:
               executor:
                 - node
+                - node22_14
+          requires:
+            - checkout
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/build:
           name: tool-kit/build-<< matrix.executor >>
-          requires:
-            - tool-kit/setup-<< matrix.executor >>
           matrix:
             parameters:
               executor:
                 - node
+                - node22_14
+          requires:
+            - tool-kit/setup-<< matrix.executor >>
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/test:
           name: tool-kit/test-<< matrix.executor >>
-          requires:
-            - tool-kit/build-<< matrix.executor >>
           matrix:
             parameters:
               executor:
                 - node
+                - node22_14
+          requires:
+            - tool-kit/build-<< matrix.executor >>
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/publish-tag:
+          executor: node
           requires:
             - tool-kit/test-node
-          name: tool-kit/publish-tag-node
-          executor: node
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -89,25 +88,28 @@ workflows:
       - checkout
       - tool-kit/setup:
           name: tool-kit/setup-<< matrix.executor >>
+          matrix:
+            parameters:
+              executor:
+                - node
+                - node22_14
           requires:
             - checkout
-          matrix:
-            parameters:
-              executor:
-                - node
       - tool-kit/build:
           name: tool-kit/build-<< matrix.executor >>
+          matrix:
+            parameters:
+              executor:
+                - node
+                - node22_14
           requires:
             - tool-kit/setup-<< matrix.executor >>
-          matrix:
-            parameters:
-              executor:
-                - node
       - tool-kit/test:
           name: tool-kit/test-<< matrix.executor >>
-          requires:
-            - tool-kit/build-<< matrix.executor >>
           matrix:
             parameters:
               executor:
                 - node
+                - node22_14
+          requires:
+            - tool-kit/build-<< matrix.executor >>

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /coverage
 /.nyc_output/
 /.vscode
+.toolkitstate/

--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -5,7 +5,7 @@ plugins:
   - '@dotcom-tool-kit/mocha'
   - '@dotcom-tool-kit/eslint'
   - '@dotcom-tool-kit/prettier'
-hooks:
+commands:
   test:local:
     - Eslint
     - Mocha
@@ -13,12 +13,16 @@ hooks:
     - Eslint
     - Mocha
 options:
-  '@dotcom-tool-kit/mocha':
-    configPath: '.mocharc.json'
-    files: 'test/**/*-spec.js'
-  '@dotcom-tool-kit/eslint':
-    files: '**/*.{js,yml,json}'
-  '@dotcom-tool-kit/prettier':
-    files: '**/*.{js,yml,json}'
-  '@dotcom-tool-kit/circleci':
-    nodeVersion: 18.16-browsers
+  plugins:
+    '@dotcom-tool-kit/circleci':
+      cimgNodeVersions:
+        - '20.19'
+        - '22.14'
+  tasks:
+    '@dotcom-tool-kit/mocha':
+      configPath: '.mocharc.json'
+      files: 'test/**/*-spec.js'
+    '@dotcom-tool-kit/eslint':
+      files: '**/*.{js,yml,json}'
+    '@dotcom-tool-kit/prettier':
+      files: '**/*.{js,yml,json}'

--- a/lib/helpers/handle-response.js
+++ b/lib/helpers/handle-response.js
@@ -11,7 +11,7 @@ function handleResponse(response) {
 			statusText: response.statusText
 		});
 
-		return response.textConverted().then((text) => {
+		return response.text().then((text) => {
 			throw httpError(response.status, text || response.statusText);
 		});
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,18 @@
 				"signed-aws-es-fetch": "^1.6.0"
 			},
 			"devDependencies": {
-				"@dotcom-tool-kit/circleci": "^6.0.1",
-				"@dotcom-tool-kit/circleci-npm": "^5.3.5",
-				"@dotcom-tool-kit/eslint": "^3.2.0",
-				"@dotcom-tool-kit/mocha": "^3.2.1",
-				"@dotcom-tool-kit/npm": "^3.3.2",
-				"@dotcom-tool-kit/prettier": "^3.2.1",
+				"@dotcom-tool-kit/circleci": "^7.6.1",
+				"@dotcom-tool-kit/circleci-npm": "^6.1.12",
+				"@dotcom-tool-kit/eslint": "^4.3.1",
+				"@dotcom-tool-kit/mocha": "^4.4.1",
+				"@dotcom-tool-kit/npm": "^4.2.11",
+				"@dotcom-tool-kit/prettier": "^4.3.1",
 				"@financial-times/eslint-config-next": "^4.0.0",
 				"@financial-times/secret-squirrel": "^2.21.0",
 				"chai": "^4.1.0",
 				"check-engine": "^1.14.0",
 				"coveralls": "^3.0.0",
-				"dotcom-tool-kit": "^3.5.2",
+				"dotcom-tool-kit": "^4.7.0",
 				"eslint": "^8.21.0",
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-json": "^3.1.0",
@@ -37,8 +37,8 @@
 				"sinon": "^5.0.0"
 			},
 			"engines": {
-				"node": "18.x || 20.x || 22.x",
-				"npm": "9.x || 10.x"
+				"node": "20.x || 22.x",
+				"npm": "10.x"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -50,56 +50,129 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@actions/exec": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
-			"integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+		"node_modules/@apaleslimghost/boxen": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@apaleslimghost/boxen/-/boxen-5.1.3.tgz",
+			"integrity": "sha512-UkSSOihJUY2VKdU0WE8NH6xgB/P1iMEODkaXlRqCh5WDZ/8weZq/eHblFJM+F9CCd+QMkIbp2TjCmJB1A9rTRg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@actions/io": "^1.0.1"
-			}
-		},
-		"node_modules/@actions/io": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
-			"integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
-			"dev": true
-		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.24.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.2.tgz",
-			"integrity": "sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/highlight": "^7.24.2",
-				"picocolors": "^1.0.0"
+				"ansi-align": "^3.0.0",
+				"camelcase": "^6.2.0",
+				"chalk": "^4.1.0",
+				"cli-boxes": "^2.2.1",
+				"string-width": "^4.2.2",
+				"type-fest": "^0.20.2",
+				"widest-line": "^3.1.0",
+				"wrap-ansi": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-			"integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+		"node_modules/@apaleslimghost/boxen/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.24.2",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.2.tgz",
-			"integrity": "sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==",
-			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.22.20",
-				"chalk": "^2.4.2",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
+				"color-convert": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=6.9.0"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@apaleslimghost/boxen/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@apaleslimghost/boxen/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@apaleslimghost/boxen/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@apaleslimghost/boxen/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@apaleslimghost/boxen/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@apaleslimghost/boxen/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@apaleslimghost/boxen/node_modules/type-fest": {
+			"version": "0.20.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@colors/colors": {
@@ -107,6 +180,7 @@
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
 			"integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.1.90"
 			}
@@ -116,6 +190,7 @@
 			"resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
 			"integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"colorspace": "1.1.x",
 				"enabled": "2.0.x",
@@ -158,241 +233,366 @@
 				"npm": "7.x || 8.x || 9.x"
 			}
 		},
-		"node_modules/@dotcom-tool-kit/circleci": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci/-/circleci-6.0.3.tgz",
-			"integrity": "sha512-TQqpAxRc8OFDYc7Ia0/+L4vMKFR6AqyyXe7YC3ul4VPFWO5wKc58PHtVBkOUKRnbQpMeVLIe4SbGWm/OhwCzJw==",
+		"node_modules/@dotcom-tool-kit/base": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/base/-/base-1.2.0.tgz",
+			"integrity": "sha512-MbVePlY6QDP8Lm1H7cIUfw42wI8HaOR+tLVUYYApNaBI2XIzEbb+w5oyKEd8MlL0KhvVSpHyQe6C3fSdVwlmIQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@dotcom-tool-kit/error": "^3.2.0",
-				"@dotcom-tool-kit/logger": "^3.4.1",
-				"@dotcom-tool-kit/state": "^3.3.0",
-				"@dotcom-tool-kit/types": "^3.6.1",
+				"@dotcom-tool-kit/conflict": "^1.0.1",
+				"@dotcom-tool-kit/logger": "^4.1.1",
+				"@dotcom-tool-kit/validated": "^1.0.2",
+				"semver": "^7.5.4",
+				"winston": "^3.11.0"
+			},
+			"peerDependencies": {
+				"zod": "^3.22.4"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/circleci": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci/-/circleci-7.6.1.tgz",
+			"integrity": "sha512-m8mSRMU172DzD7BOityK1Ut5V+K/dQsSHfkJRiFv+JxuYOdehkIKo54XJ7Yxdcp7iKFw1sNPzEkQ93Jh5DvbAg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@dotcom-tool-kit/base": "^1.2.0",
+				"@dotcom-tool-kit/conflict": "^1.0.1",
+				"@dotcom-tool-kit/error": "^4.1.0",
+				"@dotcom-tool-kit/logger": "^4.1.1",
+				"@dotcom-tool-kit/state": "^4.3.1",
 				"jest-diff": "^29.5.0",
 				"lodash": "^4.17.21",
 				"tslib": "^2.3.1",
 				"type-fest": "^3.5.4",
-				"yaml": "^2.1.1"
+				"yaml": "^2.1.1",
+				"zod": "^3.22.4"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			},
 			"peerDependencies": {
-				"dotcom-tool-kit": "3.x"
+				"dotcom-tool-kit": "4.x",
+				"zod": "^3.22.4"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/circleci-npm": {
-			"version": "5.3.5",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci-npm/-/circleci-npm-5.3.5.tgz",
-			"integrity": "sha512-4iXbOdTqxGxUMYCRVUuelaPL/VSIfrno1Xxnifln8ncnzW1/MyPzbtmd0F9rKvvzPc2D1/eXHTykHVqnraFoSA==",
+			"version": "6.1.12",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci-npm/-/circleci-npm-6.1.12.tgz",
+			"integrity": "sha512-pD3XiShsEa9xLcYhazSH06XGPq1piWdtCtR3RJTKj7CiNhXtWqYK5X8BgGnDs7Fmlwl8+zTjZhNC7LdnPbWu6A==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@dotcom-tool-kit/circleci": "^6.0.3",
-				"@dotcom-tool-kit/npm": "^3.3.2",
-				"@dotcom-tool-kit/types": "^3.6.1",
+				"@dotcom-tool-kit/circleci": "^7.6.1",
+				"@dotcom-tool-kit/npm": "^4.2.11",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			},
 			"peerDependencies": {
-				"dotcom-tool-kit": "3.x"
+				"dotcom-tool-kit": "4.x"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/config": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/config/-/config-1.1.0.tgz",
+			"integrity": "sha512-9MsVRzRuItegYIrLtBKfD6pFkZW/1c+SEevNeqC3jPj9nVaMiCl6kHL1WMU5TnNXo7MAAz8Tb162r5QOuJFKgw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@dotcom-tool-kit/conflict": "^1.0.1",
+				"@dotcom-tool-kit/plugin": "^1.1.0",
+				"@dotcom-tool-kit/validated": "^1.0.2"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/conflict": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/conflict/-/conflict-1.0.1.tgz",
+			"integrity": "sha512-u8ha4ZxbkYtcG06HiBbz8ygeqCfynCL7ONM/SHMDYgWJZw4H9YqrTxc5PGrqTv+K2kL2/8qqmsO8fKi/2PFsCw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@dotcom-tool-kit/plugin": "^1.1.0"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/error": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/error/-/error-3.2.0.tgz",
-			"integrity": "sha512-sVWzEZc7BHS9pHT+PFxKPpI4sOwEigejibTE+csybuR0n/BIJLlVB3QvJZFS+l5x7M219+kpFVCI5+JQHqyoKQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/error/-/error-4.1.0.tgz",
+			"integrity": "sha512-mHHBUrTjjVqh/TNIpmEGwdX2XZ11Zs/un0TvGFbuazDkBRvWAyrf3aIis+M/ZTb1hBkQfWK/XEMdJknOCocm/Q==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/eslint": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/eslint/-/eslint-3.2.0.tgz",
-			"integrity": "sha512-uQp05m2ToKiH4GpYwLXFELW0HeaFdcqa3oppdDL6GNamPOXpvph8kilVACK3LLeKY+BQdrwFNvwRclPkgEarrA==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/eslint/-/eslint-4.3.1.tgz",
+			"integrity": "sha512-fw35yANXBk9UoyK4AOMyfX8W/bgocmKSnCMFPqZEHSjgtdesP7WrAl1OXAPyLzae4cWulqrc+GArJiZ3DOR8cQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@dotcom-tool-kit/error": "^3.2.0",
-				"@dotcom-tool-kit/logger": "^3.4.0",
-				"@dotcom-tool-kit/types": "^3.6.0",
-				"tslib": "^2.3.1"
+				"@dotcom-tool-kit/base": "^1.2.0",
+				"@dotcom-tool-kit/error": "^4.1.0",
+				"@dotcom-tool-kit/logger": "^4.1.1",
+				"tslib": "^2.3.1",
+				"zod": "^3.24.1"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			},
 			"peerDependencies": {
-				"dotcom-tool-kit": "3.x",
+				"dotcom-tool-kit": "4.x",
 				"eslint": "7.x || 8.x"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/logger": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/logger/-/logger-3.4.1.tgz",
-			"integrity": "sha512-mpKAVjVRxXUvVkWMr4y3QZwueWatoOwznkg1oZ55SFpvzfVFGDMUET5RN4RyAsuQWo0R6eE/mKlX7/V/EWHrsQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/logger/-/logger-4.1.1.tgz",
+			"integrity": "sha512-pkS5LYv0/GCVEFx5OeAVAjhQSm/okRfokCd6aKlLXVGOAgwF+1f+pvP51oNatd2+6TVeNkXk7wIO6GkT+2nXZA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@dotcom-tool-kit/error": "^3.2.0",
-				"ansi-colors": "^4.1.1",
+				"@apaleslimghost/boxen": "^5.1.3",
+				"@dotcom-tool-kit/error": "^4.1.0",
 				"ansi-regex": "^5.0.1",
+				"chalk": "^4.1.0",
 				"triple-beam": "^1.3.0",
 				"tslib": "^2.3.1",
 				"winston": "^3.5.1",
 				"winston-transport": "^4.4.2"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/logger/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/logger/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/logger/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/logger/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@dotcom-tool-kit/logger/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/logger/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/mocha": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/mocha/-/mocha-3.2.1.tgz",
-			"integrity": "sha512-6Xmk2VvgjdCfrlxFIXPlByPpCgue96nUu7PngUyHmY49yycRXJTOAWPJKorYA+9l17ZkkvOHDWA6poHFeCf5qA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/mocha/-/mocha-4.4.1.tgz",
+			"integrity": "sha512-KmT/MnfFFqmUWbLU3mPTgcVDn8citmx928xiWxhY7TyT5EnCLmYkq08SbAe6yl2JLs5D3mKxe2eI5CD7PHs4Eg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@dotcom-tool-kit/error": "^3.2.0",
-				"@dotcom-tool-kit/logger": "^3.4.1",
-				"@dotcom-tool-kit/types": "^3.6.1",
+				"@dotcom-tool-kit/base": "^1.2.0",
+				"@dotcom-tool-kit/error": "^4.1.0",
+				"@dotcom-tool-kit/logger": "^4.1.1",
 				"glob": "^7.1.7",
-				"tslib": "^2.3.1"
+				"tslib": "^2.3.1",
+				"zod": "^3.24.1"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			},
 			"peerDependencies": {
-				"dotcom-tool-kit": "3.x",
-				"mocha": ">=6.x <=10.x"
+				"dotcom-tool-kit": "4.x",
+				"mocha": ">=6.x <=11.x"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/npm": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/npm/-/npm-3.3.2.tgz",
-			"integrity": "sha512-Q/N/prvlACbudf9CXOaA9NGtQbRXmSYtyRKpiyZok4HjegJvZ0ix7+5BjJt0/4yf6lr60FgcZ/zd2J4Lm673Xw==",
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/npm/-/npm-4.2.11.tgz",
+			"integrity": "sha512-YsVMYWPD10wKJTByi6fIMqhbcN2KHgNlncq+Qll6kw75bvzQthMM3RE1VGwANb98YvQsfuWYk/aHxSfCGvrcXg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@actions/exec": "^1.1.0",
-				"@dotcom-tool-kit/error": "^3.2.0",
-				"@dotcom-tool-kit/package-json-hook": "^4.2.0",
-				"@dotcom-tool-kit/state": "^3.3.0",
-				"@dotcom-tool-kit/types": "^3.6.1",
+				"@dotcom-tool-kit/base": "^1.2.0",
+				"@dotcom-tool-kit/error": "^4.1.0",
+				"@dotcom-tool-kit/package-json-hook": "^5.2.1",
+				"@dotcom-tool-kit/state": "^4.3.1",
 				"libnpmpack": "^3.1.0",
 				"libnpmpublish": "^5.0.1",
 				"pacote": "^12.0.3",
-				"tar": "^4.4.16",
+				"tar": "^6.2.1",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			},
 			"peerDependencies": {
-				"dotcom-tool-kit": "3.x"
-			}
-		},
-		"node_modules/@dotcom-tool-kit/options": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/options/-/options-3.2.1.tgz",
-			"integrity": "sha512-nGLQYaPrCFjuxnf+sEMMoa85Woo55NB0U/7uKXHOxjgVDnCWx7DFxDawKgi3Ufn4ZrsGMnd0fFJmfmzEIj6KTg==",
-			"dev": true,
-			"dependencies": {
-				"@dotcom-tool-kit/types": "^3.6.1",
-				"tslib": "^2.3.1"
-			},
-			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"dotcom-tool-kit": "4.x"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/package-json-hook": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/package-json-hook/-/package-json-hook-4.2.0.tgz",
-			"integrity": "sha512-wQVO5s3zhanIOv9zNjn7KEFlFkEXlZfDaZocki1m6RJHzzzEkMpZSfhR9lZcHm+xdOlnjYybPLN5lslUMLAlsg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/package-json-hook/-/package-json-hook-5.2.1.tgz",
+			"integrity": "sha512-smTIwfLMPM+zI4a5QqPAxE3k08xJ+i7n8CYVfZh6FTHd85PycClKexwUNPzfYvhhjkwwoOBTUr1lNtIN3h6dSw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
+				"@dotcom-tool-kit/base": "^1.2.0",
+				"@dotcom-tool-kit/conflict": "^1.0.1",
+				"@dotcom-tool-kit/plugin": "^1.1.0",
 				"@financial-times/package-json": "^3.0.0",
 				"lodash": "^4.17.21",
-				"tslib": "^2.3.1"
+				"tslib": "^2.3.1",
+				"zod": "^3.22.4"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
+			},
+			"peerDependencies": {
+				"zod": "^3.22.4"
 			}
 		},
-		"node_modules/@dotcom-tool-kit/prettier": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/prettier/-/prettier-3.2.1.tgz",
-			"integrity": "sha512-3CcjXQWv8LvSX3L6WiqIk+IAWf5Iy//P88ZpxD00TY+D0yDtcReAEhoNftHOfawpoiEBRrjkS9OoKbtE+/NGsQ==",
+		"node_modules/@dotcom-tool-kit/plugin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/plugin/-/plugin-1.1.0.tgz",
+			"integrity": "sha512-G8IYLIgLlBmsTb+VtwIOpddIkSZB4/+jT1ra+6UtcpgHKGFpCwj5L116mVt9gq7duvSHpO5ApjyglcjfJjJ7LQ==",
 			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@dotcom-tool-kit/prettier": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/prettier/-/prettier-4.3.1.tgz",
+			"integrity": "sha512-JuyREx8ysWy2azQQQl/ffw/CfRRL7Kngh5CAZQwUDPwDk5KAQ7G+LKBiYDZ3C2EOSj/wwJgc2TFTmj0zb0hWpA==",
+			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@dotcom-tool-kit/error": "^3.2.0",
-				"@dotcom-tool-kit/logger": "^3.4.1",
-				"@dotcom-tool-kit/package-json-hook": "^4.2.0",
-				"@dotcom-tool-kit/types": "^3.6.1",
+				"@dotcom-tool-kit/base": "^1.2.0",
+				"@dotcom-tool-kit/error": "^4.1.0",
+				"@dotcom-tool-kit/logger": "^4.1.1",
+				"@dotcom-tool-kit/package-json-hook": "^5.2.1",
 				"fast-glob": "^3.2.7",
 				"hook-std": "^2.0.0",
 				"prettier": "^2.2.1",
-				"tslib": "^2.3.1"
+				"tslib": "^2.3.1",
+				"zod": "^3.24.1"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			},
 			"peerDependencies": {
-				"dotcom-tool-kit": "3.x"
+				"dotcom-tool-kit": "4.x"
+			}
+		},
+		"node_modules/@dotcom-tool-kit/schemas": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/schemas/-/schemas-1.9.0.tgz",
+			"integrity": "sha512-dgYN3c8J51CFc7iI69Ca0Sy+D2+k/dmevR2NDOPqn4ohJcLvC8/VAVBR961MLWobObBMmodf8d9mmZz4UPnQSw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"@dotcom-tool-kit/logger": "^4.1.1"
+			},
+			"peerDependencies": {
+				"zod": "^3.22.4"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/state": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/state/-/state-3.3.0.tgz",
-			"integrity": "sha512-OGJ+ApCUwe+24TjOpubowK/HPBJVX4P7CqJKzNNXYsEZCYS3Th2ilrKqlDN5ajAL8qOK1EhGHFA+DO0wd1PbLg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/state/-/state-4.3.1.tgz",
+			"integrity": "sha512-dWrZFvAQGtMJIpF/lWCYOjvVyejCJnT4DSySkZuJRiSBrY/N1hM2mIEqlnUG2AfR7qFGovxuzXi7ywOjNFMrxg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			}
 		},
-		"node_modules/@dotcom-tool-kit/types": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/types/-/types-3.6.1.tgz",
-			"integrity": "sha512-mji6w1lHrdPGwE22mZ8jSn39qUCE9JJEJC6ewaLZQskrpclFudW3PXziwueo57u1XkonkmkMGMP4lINDInuJTw==",
+		"node_modules/@dotcom-tool-kit/validated": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/validated/-/validated-1.0.2.tgz",
+			"integrity": "sha512-f+c81/EMBsE+ewnlAGY0UE9BYwo49ezz79mLM2AQ0ZydY6+8cRbiAPKUgDg7++YeM0l5KOBXL0CNiwY8K/pKKg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"@dotcom-tool-kit/error": "^3.2.0",
-				"@dotcom-tool-kit/logger": "^3.4.1",
-				"semver": "^7.3.7",
-				"tslib": "^2.3.1",
-				"zod": "^3.20.2"
-			},
-			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"@dotcom-tool-kit/error": "^4.1.0"
 			}
 		},
 		"node_modules/@dotcom-tool-kit/wait-for-ok": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/wait-for-ok/-/wait-for-ok-3.2.0.tgz",
-			"integrity": "sha512-jqpXNhqd//AKU8IJxgxZS1vlLsBIg3FcgdTEoxIPASusfDcot+vxFQRBxYDJSxp5zpwhHWRSUjUgorNApj5efA==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@dotcom-tool-kit/wait-for-ok/-/wait-for-ok-4.1.0.tgz",
+			"integrity": "sha512-dJosewNjOvlWR9XEUvrBk0MdVTiKsaWTVmV+nIDMOW5n1jPRGhXLeCljMnaD3bUe75DSrRXLxWHgFN+Py7c7bQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"node-fetch": "^2.6.8",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
+				"node": "18.x || 20.x || 22.x"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -488,7 +688,8 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@financial-times/package-json/-/package-json-3.0.0.tgz",
 			"integrity": "sha512-me2zEJv7VF0z1EIMh9+Q6bH8BHp3RyINunPcejOAd/IkxKgmksRs2KlKsxe3Yw+4HAVezdB3vs46kwqTGv1xJg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@financial-times/secret-squirrel": {
 			"version": "2.21.1",
@@ -512,7 +713,8 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.14",
@@ -599,6 +801,7 @@
 			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
 			"integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@gar/promisify": "^1.0.1",
 				"semver": "^7.3.5"
@@ -609,6 +812,7 @@
 			"resolved": "https://registry.npmjs.org/@npmcli/git/-/git-2.1.0.tgz",
 			"integrity": "sha512-/hBFX/QG1b+N7PZBFs0bi+evgRZcK9nWBxQKZkGoXUT5hJSwl5c4d7y8/hm+NQZRPhQ67RzFaj5UM9YeyKoryw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/promise-spawn": "^1.3.2",
 				"lru-cache": "^6.0.0",
@@ -625,6 +829,7 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			},
@@ -637,6 +842,7 @@
 			"resolved": "https://registry.npmjs.org/@npmcli/installed-package-contents/-/installed-package-contents-1.0.7.tgz",
 			"integrity": "sha512-9rufe0wnJusCQoLpV9ZPKIVP55itrM5BxOXs10DmdbRfgWtHy1LDyskbwRnBghuB0PrF7pNPOqREVtpz4HqzKw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"npm-bundled": "^1.1.1",
 				"npm-normalize-package-bin": "^1.0.1"
@@ -654,6 +860,7 @@
 			"integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
 			"deprecated": "This functionality has been moved to @npmcli/fs",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mkdirp": "^1.0.4",
 				"rimraf": "^3.0.2"
@@ -667,6 +874,7 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			},
@@ -678,13 +886,15 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.3.tgz",
 			"integrity": "sha512-fnkhw+fmX65kiLqk6E3BFLXNC26rUhK90zVwe2yncPliVT/Qos3xjhTLE59Df8KnPlcwIERXKVlU1bXoUQ+liA==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/@npmcli/promise-spawn": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-1.3.2.tgz",
 			"integrity": "sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"infer-owner": "^1.0.4"
 			}
@@ -694,6 +904,7 @@
 			"resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-2.0.0.tgz",
 			"integrity": "sha512-fSan/Pu11xS/TdaTpTB0MRn9guwGU8dye+x56mEVgBEd/QsybBbYcAL0phPXi8SGWFEChkQd6M9qL4y6VOpFig==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/node-gyp": "^1.0.2",
 				"@npmcli/promise-spawn": "^1.3.2",
@@ -747,21 +958,17 @@
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/@types/parse-json": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-			"dev": true
 		},
 		"node_modules/@types/triple-beam": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
 			"integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.2.0",
@@ -773,7 +980,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",
@@ -812,6 +1020,7 @@
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
 			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"debug": "4"
 			},
@@ -820,10 +1029,11 @@
 			}
 		},
 		"node_modules/agentkeepalive": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-			"integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+			"integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"humanize-ms": "^1.2.1"
 			},
@@ -836,6 +1046,7 @@
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
 			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
@@ -860,13 +1071,14 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/ansi-colors": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-			"integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+		"node_modules/ansi-align": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
 			"dev": true,
-			"engines": {
-				"node": ">=6"
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.1.0"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -894,13 +1106,16 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
 			"integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/are-we-there-yet": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
 			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^3.6.0"
@@ -1040,10 +1255,11 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
-			"dev": true
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
@@ -1183,13 +1399,15 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
 			"integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/cacache": {
 			"version": "15.3.0",
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
 			"integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/fs": "^1.0.0",
 				"@npmcli/move-file": "^1.0.1",
@@ -1219,37 +1437,12 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/cacache/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/cacache/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/call-bind": {
@@ -1409,6 +1602,7 @@
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
 			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=10"
 			}
@@ -1418,8 +1612,22 @@
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/cli-boxes": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+			"integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cliui": {
@@ -1441,6 +1649,7 @@
 			"resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
 			"integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^1.9.3",
 				"color-string": "^1.6.0"
@@ -1466,6 +1675,7 @@
 			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
 			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color-name": "^1.0.0",
 				"simple-swizzle": "^0.2.2"
@@ -1476,6 +1686,7 @@
 			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
 			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"color-support": "bin.js"
 			}
@@ -1500,6 +1711,7 @@
 			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
 			"integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"color": "^3.1.3",
 				"text-hex": "1.0.x"
@@ -1542,38 +1754,14 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
 			"dev": true
-		},
-		"node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"dev": true,
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/coveralls": {
 			"version": "3.1.1",
@@ -1706,6 +1894,13 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/dedent": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+			"integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/deep-eql": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -1780,7 +1975,8 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/denodeify": {
 			"version": "1.2.1",
@@ -1826,39 +2022,36 @@
 			}
 		},
 		"node_modules/dotcom-tool-kit": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/dotcom-tool-kit/-/dotcom-tool-kit-3.5.2.tgz",
-			"integrity": "sha512-ZOX2uZRXjH7hk9hKqK28Me0MMR8gr+Vui4PJ3zVDCMUaS7jnasDUCbUMxfHBgrAwZKQ+uOkbBoJUeLLNwdKobA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/dotcom-tool-kit/-/dotcom-tool-kit-4.7.0.tgz",
+			"integrity": "sha512-M+IOvwoz/aXkIzBjE1uYjuw7ohdHY/SP7UOl0ls3Lugn58QUTDjsZo1UhAQRDLAvSb1UoAHDi/2fsyIIAxtNkA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@dotcom-tool-kit/error": "^3.2.0",
-				"@dotcom-tool-kit/logger": "^3.4.1",
-				"@dotcom-tool-kit/options": "^3.2.1",
-				"@dotcom-tool-kit/types": "^3.6.1",
-				"@dotcom-tool-kit/wait-for-ok": "^3.2.0",
-				"cosmiconfig": "^7.0.0",
+				"@dotcom-tool-kit/base": "^1.2.0",
+				"@dotcom-tool-kit/config": "^1.1.0",
+				"@dotcom-tool-kit/conflict": "^1.0.1",
+				"@dotcom-tool-kit/error": "^4.1.0",
+				"@dotcom-tool-kit/logger": "^4.1.1",
+				"@dotcom-tool-kit/plugin": "^1.1.0",
+				"@dotcom-tool-kit/schemas": "^1.9.0",
+				"@dotcom-tool-kit/state": "^4.3.1",
+				"@dotcom-tool-kit/validated": "^1.0.2",
+				"@dotcom-tool-kit/wait-for-ok": "^4.1.0",
+				"endent": "^2.1.0",
 				"lodash": "^4.17.21",
 				"minimist": "^1.2.5",
-				"resolve-from": "^5.0.0",
+				"pluralize": "^8.0.0",
+				"pretty-format": "^29.7.0",
 				"tslib": "^2.3.1",
-				"yaml": "^1.10.2",
-				"zod-validation-error": "^0.3.0"
+				"yaml": "^2.4.1",
+				"zod-validation-error": "^2.1.0"
 			},
 			"bin": {
 				"dotcom-tool-kit": "bin/run"
 			},
 			"engines": {
-				"node": "16.x || 18.x || 20.x",
-				"npm": "7.x || 8.x || 9.x || 10.x"
-			}
-		},
-		"node_modules/dotcom-tool-kit/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
+				"node": "18.x || 20.x || 22.x"
 			}
 		},
 		"node_modules/ecc-jsbn": {
@@ -1887,7 +2080,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
 			"integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/encoding": {
 			"version": "0.1.13",
@@ -1907,11 +2101,24 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/endent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/endent/-/endent-2.1.0.tgz",
+			"integrity": "sha512-r8VyPX7XL8U01Xgnb1CjZ3XV+z90cXIJ9JPE/R9SEC9vpw2P6CfsRPJmp20DppC5N7ZAMCmjYkJIa744Iyg96w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dedent": "^0.7.0",
+				"fast-json-parse": "^1.0.3",
+				"objectorarray": "^1.0.5"
+			}
+		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
 			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -1920,16 +2127,8 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
 			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-			"dev": true
-		},
-		"node_modules/error-ex": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
-			"dependencies": {
-				"is-arrayish": "^0.2.1"
-			}
+			"license": "MIT"
 		},
 		"node_modules/es-abstract": {
 			"version": "1.23.3",
@@ -2527,6 +2726,13 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/fast-json-parse": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+			"integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2566,7 +2772,8 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
 			"integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
@@ -2644,7 +2851,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
 			"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/for-each": {
 			"version": "0.3.3",
@@ -2683,6 +2891,7 @@
 			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
 			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -2736,7 +2945,9 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
 			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"aproba": "^1.0.3 || ^2.0.0",
 				"color-support": "^1.1.3",
@@ -2756,6 +2967,7 @@
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
 			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
@@ -3026,7 +3238,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
@@ -3069,6 +3282,7 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
 			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -3080,7 +3294,8 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
 			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/http-errors": {
 			"version": "1.8.1",
@@ -3102,6 +3317,7 @@
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
 			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@tootallnate/once": "1",
 				"agent-base": "6",
@@ -3131,6 +3347,7 @@
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
 			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"agent-base": "6",
 				"debug": "4"
@@ -3144,6 +3361,7 @@
 			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
 			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.0.0"
 			}
@@ -3208,6 +3426,7 @@
 			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-4.0.1.tgz",
 			"integrity": "sha512-rzDQLaW4jQbh2YrOFlJdCtX8qgJTehFRYiUB2r1osqTeDzV/3+Jh8fz1oAPzUThf3iku8Ds4IDqawI5d8mUiQw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minimatch": "^3.0.4"
 			},
@@ -3254,6 +3473,7 @@
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
 			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			}
@@ -3262,7 +3482,8 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
 			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
@@ -3298,6 +3519,7 @@
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
 			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"jsbn": "1.1.0",
 				"sprintf-js": "^1.1.3"
@@ -3310,7 +3532,8 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
 			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"dev": true
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/is-arguments": {
 			"version": "1.1.1",
@@ -3345,10 +3568,11 @@
 			}
 		},
 		"node_modules/is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-			"dev": true
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-bigint": {
 			"version": "1.0.4",
@@ -3414,12 +3638,16 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.13.1",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-			"integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"hasown": "^2.0.0"
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3489,7 +3717,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-map": {
 			"version": "2.0.3",
@@ -3596,6 +3825,7 @@
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8"
 			},
@@ -3809,12 +4039,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
-		},
 		"node_modules/js-yaml": {
 			"version": "3.14.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -3832,7 +4056,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
 			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
@@ -3844,7 +4069,8 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json-schema": {
 			"version": "0.4.0",
@@ -3895,7 +4121,8 @@
 			"dev": true,
 			"engines": [
 				"node >= 0.2.0"
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/jsprim": {
 			"version": "1.4.2",
@@ -3931,7 +4158,8 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
 			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lcov-parse": {
 			"version": "1.0.0",
@@ -3960,6 +4188,7 @@
 			"resolved": "https://registry.npmjs.org/libnpmpack/-/libnpmpack-3.1.0.tgz",
 			"integrity": "sha512-dO0ER8L6TPINOSyCAy/XTwsKIz42Bg+SB1XX9zCoaHimP7oqzV7O8PJGoPfEduLt8zidwu8oNW3nYrA43M6VCQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/run-script": "^2.0.0",
 				"npm-package-arg": "^8.1.0",
@@ -3974,6 +4203,7 @@
 			"resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-5.0.1.tgz",
 			"integrity": "sha512-S9HvvO8kGWWuGFvAQyw0T5NWxib21ktA1REGTB7I+GBqDjyYOjjwzJaavtTxDD8ID18dKCluOXg0PdMmRdKfHA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"normalize-package-data": "^3.0.2",
 				"npm-package-arg": "^8.1.2",
@@ -3984,12 +4214,6 @@
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
-		},
-		"node_modules/lines-and-columns": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-			"dev": true
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -4051,10 +4275,11 @@
 			}
 		},
 		"node_modules/logform": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
-			"integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+			"integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@colors/colors": "1.6.0",
 				"@types/triple-beam": "^1.3.2",
@@ -4099,6 +4324,7 @@
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
 			"integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"agentkeepalive": "^4.1.3",
 				"cacache": "^15.2.0",
@@ -4189,6 +4415,7 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
 			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"yallist": "^4.0.0"
 			},
@@ -4201,6 +4428,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
 			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -4213,6 +4441,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
 			"integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"minipass": "^3.1.0",
 				"minipass-sized": "^1.0.3",
@@ -4230,6 +4459,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
 			"integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -4238,10 +4468,11 @@
 			}
 		},
 		"node_modules/minipass-json-stream": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/minipass-json-stream/-/minipass-json-stream-1.0.1.tgz",
-			"integrity": "sha512-ODqY18UZt/I8k+b7rl2AENgbWE8IDYam+undIJONvigAz8KR5GWblsFTEfQs0WODsjbSXWlm+JHEv8Gr6Tfdbg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/minipass-json-stream/-/minipass-json-stream-1.0.2.tgz",
+			"integrity": "sha512-myxeeTm57lYs8pH2nxPzmEEg8DGIgW+9mv6D4JZD2pa81I/OBjeU7PtICXV6c9eRGTA5JMDsuIPUZRCyBMYNhg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"jsonparse": "^1.3.1",
 				"minipass": "^3.0.0"
@@ -4252,6 +4483,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
 			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -4264,6 +4496,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
 			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.0.0"
 			},
@@ -4276,6 +4509,7 @@
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
 			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"minipass": "^3.0.0",
 				"yallist": "^4.0.0"
@@ -4617,10 +4851,11 @@
 			"dev": true
 		},
 		"node_modules/negotiator": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+			"integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -4716,6 +4951,7 @@
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
 			"integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.0",
 				"glob": "^7.1.4",
@@ -4735,49 +4971,12 @@
 				"node": ">= 10.12.0"
 			}
 		},
-		"node_modules/node-gyp/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/node-gyp/node_modules/mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-			"dev": true,
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/node-gyp/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/nopt": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
 			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"abbrev": "1"
 			},
@@ -4793,6 +4992,7 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
 			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
 				"is-core-module": "^2.5.0",
@@ -4808,6 +5008,7 @@
 			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.2.tgz",
 			"integrity": "sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"npm-normalize-package-bin": "^1.0.1"
 			}
@@ -4817,6 +5018,7 @@
 			"resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-4.0.0.tgz",
 			"integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"semver": "^7.1.1"
 			},
@@ -4828,13 +5030,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
 			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/npm-package-arg": {
 			"version": "8.1.5",
 			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
 			"integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"hosted-git-info": "^4.0.1",
 				"semver": "^7.3.4",
@@ -4849,6 +5053,7 @@
 			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-3.0.0.tgz",
 			"integrity": "sha512-L/cbzmutAwII5glUcf2DBRNY/d0TFd4e/FnaZigJV6JD85RHZXJFGwCndjMWiiViiWSsWt3tiOLpI3ByTnIdFQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"glob": "^7.1.6",
 				"ignore-walk": "^4.0.1",
@@ -4867,6 +5072,7 @@
 			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-6.1.1.tgz",
 			"integrity": "sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"npm-install-checks": "^4.0.0",
 				"npm-normalize-package-bin": "^1.0.1",
@@ -4879,6 +5085,7 @@
 			"resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-12.0.2.tgz",
 			"integrity": "sha512-Df5QT3RaJnXYuOwtXBXS9BWs+tHH2olvkCLh6jcR/b/u3DvPMlp3J0TvvYwplPKxHMOwfg287PYih9QqaVFoKA==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"make-fetch-happen": "^10.0.1",
 				"minipass": "^3.1.6",
@@ -4896,6 +5103,7 @@
 			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
 			"integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@gar/promisify": "^1.1.3",
 				"semver": "^7.3.5"
@@ -4910,6 +5118,7 @@
 			"integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
 			"deprecated": "This functionality has been moved to @npmcli/fs",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"mkdirp": "^1.0.4",
 				"rimraf": "^3.0.2"
@@ -4923,6 +5132,7 @@
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
 			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
 			}
@@ -4932,6 +5142,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -4941,6 +5152,7 @@
 			"resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
 			"integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/fs": "^2.1.0",
 				"@npmcli/move-file": "^2.0.0",
@@ -4969,7 +5181,9 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
 			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4989,6 +5203,7 @@
 			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
 			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@tootallnate/once": "2",
 				"agent-base": "6",
@@ -5003,6 +5218,7 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
 			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
 			"dev": true,
+			"license": "ISC",
 			"engines": {
 				"node": ">=12"
 			}
@@ -5012,6 +5228,7 @@
 			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
 			"integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"agentkeepalive": "^4.2.1",
 				"cacache": "^16.1.0",
@@ -5039,6 +5256,7 @@
 			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
 			"integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"minipass": "^3.1.6",
 				"minipass-sized": "^1.0.3",
@@ -5056,6 +5274,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
 			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -5068,6 +5287,7 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			},
@@ -5080,6 +5300,7 @@
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
 			"integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^6.0.2",
 				"debug": "^4.3.3",
@@ -5094,6 +5315,7 @@
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
 			"integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.1.1"
 			},
@@ -5101,37 +5323,12 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm-registry-fetch/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/npm-registry-fetch/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/npm-registry-fetch/node_modules/unique-filename": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
 			"integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"unique-slug": "^3.0.0"
 			},
@@ -5144,6 +5341,7 @@
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
 			"integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4"
 			},
@@ -5155,7 +5353,9 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
 			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+			"deprecated": "This package is no longer supported.",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"are-we-there-yet": "^3.0.0",
 				"console-control-strings": "^1.1.0",
@@ -8867,6 +9067,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/objectorarray": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
+			"integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/on-exit-leak-free": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -8888,6 +9095,7 @@
 			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
 			"integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fn.name": "1.x.x"
 			}
@@ -8944,6 +9152,7 @@
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
 			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"aggregate-error": "^3.0.0"
 			},
@@ -8968,6 +9177,7 @@
 			"resolved": "https://registry.npmjs.org/pacote/-/pacote-12.0.3.tgz",
 			"integrity": "sha512-CdYEl03JDrRO3x18uHjBYA9TyoW8gy+ThVcypcDkxPtKlw76e4ejhYB6i9lJ+/cebbjpqPW/CijjqxwDTts8Ow==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"@npmcli/git": "^2.1.0",
 				"@npmcli/installed-package-contents": "^1.0.6",
@@ -9001,37 +9211,12 @@
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/pacote/node_modules/tar": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-			"dev": true,
-			"dependencies": {
-				"chownr": "^2.0.0",
-				"fs-minipass": "^2.0.0",
-				"minipass": "^5.0.0",
-				"minizlib": "^2.1.1",
-				"mkdirp": "^1.0.3",
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/pacote/node_modules/tar/node_modules/minipass": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/parent-module": {
@@ -9044,24 +9229,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parse-json": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"error-ex": "^1.3.1",
-				"json-parse-even-better-errors": "^2.3.0",
-				"lines-and-columns": "^1.1.6"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/path-exists": {
@@ -9106,15 +9273,6 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
 			"dev": true
 		},
-		"node_modules/path-type": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/pathval": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -9128,12 +9286,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-			"dev": true
-		},
-		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
 			"dev": true
 		},
 		"node_modules/picomatch": {
@@ -9239,6 +9391,16 @@
 			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
 			"integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
 		},
+		"node_modules/pluralize": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+			"integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -9315,13 +9477,15 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/promise-retry": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
 			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"err-code": "^2.0.2",
 				"retry": "^0.12.0"
@@ -9430,6 +9594,7 @@
 			"resolved": "https://registry.npmjs.org/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz",
 			"integrity": "sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"json-parse-even-better-errors": "^2.3.0",
 				"npm-normalize-package-bin": "^1.0.1"
@@ -9443,6 +9608,7 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -9557,20 +9723,12 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/resolve-from": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/retry": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
@@ -9805,7 +9963,8 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/signed-aws-es-fetch": {
 			"version": "1.6.0",
@@ -9823,15 +9982,10 @@
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
 			"integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-arrayish": "^0.3.1"
 			}
-		},
-		"node_modules/simple-swizzle/node_modules/is-arrayish": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-			"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-			"dev": true
 		},
 		"node_modules/sinon": {
 			"version": "5.1.1",
@@ -9854,16 +10008,18 @@
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},
 		"node_modules/socks": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.1.tgz",
-			"integrity": "sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+			"integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
@@ -9878,6 +10034,7 @@
 			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
 			"integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"agent-base": "^6.0.2",
 				"debug": "^4.3.3",
@@ -9900,6 +10057,7 @@
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
 			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"spdx-expression-parse": "^3.0.0",
 				"spdx-license-ids": "^3.0.0"
@@ -9909,23 +10067,26 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
 			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-			"dev": true
+			"dev": true,
+			"license": "CC-BY-3.0"
 		},
 		"node_modules/spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
-			"integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
-			"dev": true
+			"version": "3.0.21",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+			"integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/split2": {
 			"version": "4.2.0",
@@ -9977,6 +10138,7 @@
 			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
 			"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"minipass": "^3.1.1"
 			},
@@ -9989,6 +10151,7 @@
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
 			"integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "*"
 			}
@@ -10135,80 +10298,52 @@
 			}
 		},
 		"node_modules/tar": {
-			"version": "4.4.19",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-			"integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
-				"chownr": "^1.1.4",
-				"fs-minipass": "^1.2.7",
-				"minipass": "^2.9.0",
-				"minizlib": "^1.3.3",
-				"mkdirp": "^0.5.5",
-				"safe-buffer": "^5.2.1",
-				"yallist": "^3.1.1"
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=4.5"
-			}
-		},
-		"node_modules/tar/node_modules/chownr": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"dev": true
-		},
-		"node_modules/tar/node_modules/fs-minipass": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-			"dev": true,
-			"dependencies": {
-				"minipass": "^2.6.0"
+				"node": ">=10"
 			}
 		},
 		"node_modules/tar/node_modules/minipass": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
 			"dev": true,
-			"dependencies": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
-			}
-		},
-		"node_modules/tar/node_modules/minizlib": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-			"dev": true,
-			"dependencies": {
-				"minipass": "^2.9.0"
+			"license": "ISC",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/tar/node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
+			"license": "MIT",
 			"bin": {
 				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
-		},
-		"node_modules/tar/node_modules/yallist": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true
 		},
 		"node_modules/text-hex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
 			"integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
@@ -10267,6 +10402,7 @@
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
 			"integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 14.0.0"
 			}
@@ -10430,6 +10566,7 @@
 			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
 			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"unique-slug": "^2.0.0"
 			}
@@ -10439,6 +10576,7 @@
 			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
 			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -10465,7 +10603,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/uuid": {
 			"version": "3.4.0",
@@ -10482,6 +10621,7 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
@@ -10492,6 +10632,7 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
 			"integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"builtins": "^1.0.3"
 			}
@@ -10669,36 +10810,51 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/winston": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
-			"integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+		"node_modules/widest-line": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+			"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/winston": {
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+			"integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@colors/colors": "^1.6.0",
 				"@dabh/diagnostics": "^2.0.2",
 				"async": "^3.2.3",
 				"is-stream": "^2.0.0",
-				"logform": "^2.4.0",
+				"logform": "^2.7.0",
 				"one-time": "^1.0.0",
 				"readable-stream": "^3.4.0",
 				"safe-stable-stringify": "^2.3.1",
 				"stack-trace": "0.0.x",
 				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.7.0"
+				"winston-transport": "^4.9.0"
 			},
 			"engines": {
 				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/winston-transport": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
-			"integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+			"integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"logform": "^2.3.2",
-				"readable-stream": "^3.6.0",
+				"logform": "^2.7.0",
+				"readable-stream": "^3.6.2",
 				"triple-beam": "^1.3.0"
 			},
 			"engines": {
@@ -11041,21 +11197,23 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.22.4",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-			"integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+			"version": "3.24.2",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
 			"dev": true,
+			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/zod-validation-error": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-0.3.2.tgz",
-			"integrity": "sha512-pBXItXNDup6KF54fdnA+cmB/eEt65HlN5pmahfBTUhufWEnXs4ouU8lLXh01GoAksIR9K7iF7BxXxkKvct+r+A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+			"integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": "^14.17 || >=16.0.0"
+				"node": ">=18.0.0"
 			},
 			"peerDependencies": {
 				"zod": "^3.18.0"

--- a/package.json
+++ b/package.json
@@ -18,18 +18,18 @@
 		}
 	},
 	"devDependencies": {
-		"@dotcom-tool-kit/circleci": "^6.0.1",
-		"@dotcom-tool-kit/circleci-npm": "^5.3.5",
-		"@dotcom-tool-kit/eslint": "^3.2.0",
-		"@dotcom-tool-kit/mocha": "^3.2.1",
-		"@dotcom-tool-kit/npm": "^3.3.2",
-		"@dotcom-tool-kit/prettier": "^3.2.1",
+		"@dotcom-tool-kit/circleci": "^7.6.1",
+		"@dotcom-tool-kit/circleci-npm": "^6.1.12",
+		"@dotcom-tool-kit/eslint": "^4.3.1",
+		"@dotcom-tool-kit/mocha": "^4.4.1",
+		"@dotcom-tool-kit/npm": "^4.2.11",
+		"@dotcom-tool-kit/prettier": "^4.3.1",
 		"@financial-times/eslint-config-next": "^4.0.0",
 		"@financial-times/secret-squirrel": "^2.21.0",
 		"chai": "^4.1.0",
 		"check-engine": "^1.14.0",
 		"coveralls": "^3.0.0",
-		"dotcom-tool-kit": "^3.5.2",
+		"dotcom-tool-kit": "^4.7.0",
 		"eslint": "^8.21.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-json": "^3.1.0",
@@ -41,8 +41,11 @@
 		"sinon": "^5.0.0"
 	},
 	"engines": {
-		"node": "18.x || 20.x || 22.x",
-		"npm": "9.x || 10.x"
+		"node": "20.x || 22.x",
+		"npm": "10.x"
+	},
+	"volta": {
+		"node": "22.14.0"
 	},
 	"scripts": {
 		"prepare": "husky install",
@@ -56,8 +59,5 @@
 		"prepush": "npm run test",
 		"format": "dotcom-tool-kit format:local",
 		"coverage": "nyc --reporter=lcovonly mocha --config=.mocharc.json"
-	},
-	"volta": {
-		"node": "18.20.2"
 	}
 }


### PR DESCRIPTION
BREAKING:
* remove support for node 18

FIX:
* update response `textConverted` to `text` - the former will cause a 500 error to happen even when there are 4xx errors